### PR TITLE
Fix TOC flicker and improve document viewer

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -123,28 +123,3 @@ body,
 	z-index: 20;
 	backdrop-filter: blur(8px);
 }
-
-.document-toc {
-	position: sticky;
-	top: 0;
-	height: 100vh;
-	overflow-y: auto;
-	scrollbar-width: thin;
-}
-
-.document-toc::-webkit-scrollbar {
-	width: 6px;
-}
-
-.document-toc::-webkit-scrollbar-track {
-	background: transparent;
-}
-
-.document-toc::-webkit-scrollbar-thumb {
-	background-color: rgba(156, 163, 175, 0.5);
-	border-radius: 3px;
-}
-
-.dark .document-toc::-webkit-scrollbar-thumb {
-	background-color: rgba(75, 85, 99, 0.5);
-}

--- a/frontend/src/components/document/EnhancedDocumentViewer.tsx
+++ b/frontend/src/components/document/EnhancedDocumentViewer.tsx
@@ -15,6 +15,7 @@ import {
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { MarkdownRenderer } from "@/components/ui/MarkdownRenderer";
+import { EnhancedCodeBlock } from "./EnhancedCodeBlock";
 import { useAppStore } from "@/stores/appStore";
 import { cn } from "@/utils/cn";
 import type { Document } from "@/types";
@@ -473,52 +474,53 @@ export const EnhancedDocumentViewer: React.FC<DocumentViewerProps> = ({
 	};
 	
 	// Render EXAMPLES section with syntax highlighting
-	const renderExamplesSection = (content: string) => {
-		const examples = parseExamplesSection(content);
-		
-		return (
-			<div className="space-y-6">
-				{examples.length > 0 ? (
-					examples.map((example, idx) => (
-						<div key={idx} className="example-block">
-							{example.description && (
-								<p className="text-gray-700 dark:text-gray-100 text-sm font-medium mb-3">
-									{example.description}
-								</p>
-							)}
-							{example.code && (
-								<div className="code-block-wrapper">
-									<pre className="p-4 bg-gray-900 dark:bg-black text-gray-100 overflow-x-auto rounded-lg">
-										<code className="text-sm font-mono leading-relaxed">{example.code}</code>
-									</pre>
-								</div>
-							)}
-						</div>
-					))
-				) : (
-					// Fallback if no examples detected
-					<div className="prose dark:prose-invert max-w-none">
-						<pre className="text-sm bg-gray-100 dark:bg-gray-800 p-4 rounded-lg overflow-x-auto">
-							<code>{content}</code>
-						</pre>
-					</div>
-				)}
-			</div>
-		);
-	};
+        const renderExamplesSection = (content: string) => {
+                const examples = parseExamplesSection(content);
+
+                return (
+                        <div className="space-y-6">
+                                {examples.length > 0 ? (
+                                        examples.map((example, idx) => (
+                                                <div key={idx} className="example-block">
+                                                        {example.description && (
+                                                                <p className="text-gray-700 dark:text-gray-100 text-sm font-medium mb-3">
+                                                                        {example.description}
+                                                                </p>
+                                                        )}
+                                                        {example.code && (
+                                                                <EnhancedCodeBlock
+                                                                        code={example.code}
+                                                                        language={example.language || 'bash'}
+                                                                        showLineNumbers={showLineNumbers}
+                                                                />
+                                                        )}
+                                                </div>
+                                        ))
+                                ) : (
+                                        // Fallback if no examples detected
+                                        <EnhancedCodeBlock
+                                                code={content}
+                                                language="bash"
+                                                showLineNumbers={showLineNumbers}
+                                        />
+                                )}
+                        </div>
+                );
+        };
 	
 	// Render generic section with code block detection
-	const renderGenericSection = (content: string) => {
-		const processedContent = detectCodeBlocks(content);
-		
-		return (
-			<MarkdownRenderer 
-				content={processedContent}
-				darkMode={darkMode}
-				fontSize={fontSize}
-			/>
-		);
-	};
+        const renderGenericSection = (content: string) => {
+                const processedContent = detectCodeBlocks(content);
+
+                return (
+                        <MarkdownRenderer
+                                content={processedContent}
+                                darkMode={darkMode}
+                                fontSize={fontSize}
+                                showLineNumbers={showLineNumbers}
+                        />
+                );
+        };
 	
 	// Render SYNOPSIS section with special formatting
 	const renderSynopsisSection = (content: string) => {
@@ -697,16 +699,23 @@ export const EnhancedDocumentViewer: React.FC<DocumentViewerProps> = ({
 											A
 										</span>
 									</Button>
-									<Button
-										variant="ghost"
-										size="sm"
-										onClick={() => setShowToc(!showToc)}
-										className={cn(
-											showToc && "bg-gray-200 dark:bg-gray-700"
-										)}
-									>
-										<HamburgerMenuIcon className="w-4 h-4" />
-									</Button>
+                                                                        <Button
+                                                                               variant="ghost"
+                                                                               size="sm"
+                                                                               onClick={() => setShowLineNumbers(!showLineNumbers)}
+                                                                        >
+                                                                               <EyeOpenIcon className="w-4 h-4" />
+                                                                        </Button>
+                                                                        <Button
+                                                                               variant="ghost"
+                                                                               size="sm"
+                                                                               onClick={() => setShowToc(!showToc)}
+                                                                               className={cn(
+                                                                               showToc && "bg-gray-200 dark:bg-gray-700"
+                                                                               )}
+                                                                        >
+                                                                               <HamburgerMenuIcon className="w-4 h-4" />
+                                                                        </Button>
 								</div>
 
 								{/* Actions */}

--- a/frontend/src/components/ui/MarkdownRenderer.tsx
+++ b/frontend/src/components/ui/MarkdownRenderer.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus, vs } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { EnhancedCodeBlock } from '../document/EnhancedCodeBlock';
 import { cn } from '@/utils/cn';
 
 interface MarkdownRendererProps {
@@ -10,13 +11,15 @@ interface MarkdownRendererProps {
   className?: string;
   darkMode?: boolean;
   fontSize?: 'sm' | 'base' | 'lg';
+  showLineNumbers?: boolean;
 }
 
 export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   content,
   className,
   darkMode = false,
-  fontSize = 'base'
+  fontSize = 'base',
+  showLineNumbers = false
 }) => {
   const fontSizeClasses = {
     sm: 'prose-sm',
@@ -53,20 +56,16 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
         components={{
           code({ node, inline, className, children, ...props }) {
             const match = /language-(\w+)/.exec(className || '');
-            return !inline && match ? (
-              <SyntaxHighlighter
-                style={darkMode ? vscDarkPlus : vs}
-                language={match[1]}
-                PreTag="div"
-                className="rounded-lg overflow-hidden"
-                {...props}
-              >
-                {String(children).replace(/\n$/, '')}
-              </SyntaxHighlighter>
+            const language = match ? match[1] : undefined;
+            const codeString = String(children).replace(/\n$/, '');
+            return !inline ? (
+              <EnhancedCodeBlock
+                code={codeString}
+                language={language}
+                showLineNumbers={showLineNumbers}
+              />
             ) : (
-              <code className={className} {...props}>
-                {children}
-              </code>
+              <code className={className} {...props}>{children}</code>
             );
           },
           // Custom rendering for definition lists (common in man pages)

--- a/frontend/src/pages/DocumentPage.tsx
+++ b/frontend/src/pages/DocumentPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { ArrowLeftIcon } from "@radix-ui/react-icons";
 import { Button } from "@/components/ui/Button";
-import { EnhancedDocumentViewer } from "@/components/document/EnhancedDocumentViewer";
+import { DocumentViewerWrapper } from "@/components/document/DocumentViewerWrapper";
 import { documentAPI } from "@/services/api";
 import { useAppStore } from "@/stores/appStore";
 import type { Document } from "@/types";
@@ -119,7 +119,7 @@ export const DocumentPage: React.FC = () => {
 			exit={{ opacity: 0 }}
 			className="document-page min-h-screen bg-gray-50 dark:bg-gray-900"
 		>
-			<EnhancedDocumentViewer document={document} />
-		</motion.div>
-	);
+                        <DocumentViewerWrapper document={document} />
+                </motion.div>
+        );
 };


### PR DESCRIPTION
## Summary
- remove legacy sticky styles for document toc
- use `DocumentViewerWrapper` in document page to prevent flicker
- enhance document viewer with code block rendering and line number toggle
- update MarkdownRenderer to use `EnhancedCodeBlock`

## Testing
- `./run_tests.sh frontend` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_6848f96e99b48332a409da2812f2dbbb

## Summary by Sourcery

Fix table of contents flicker by wrapping the viewer in `DocumentViewerWrapper` and clean up legacy TOC styles, and improve document viewer by integrating `EnhancedCodeBlock` with a line number toggle in both examples and general markdown rendering.

New Features:
- Add toggle button to show or hide line numbers in code blocks within the document viewer.

Bug Fixes:
- Fix flickering of the table of contents on the document page.

Enhancements:
- Replace custom code block rendering in example and generic sections with `EnhancedCodeBlock` and propagate the `showLineNumbers` setting through `MarkdownRenderer`.
- Remove legacy sticky table of contents styles and wrap the document viewer in `DocumentViewerWrapper` to eliminate flicker.

Chores:
- Remove unused CSS rules for the legacy document table of contents.