### PR TITLE
fix(ci): install pinned Railway CLI package instead of curl|bash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,22 +271,13 @@ jobs:
 
           export RAILWAY_VERSION="4.18.1"
 
-          mkdir -p "$HOME/.local/bin"
-          export PATH="$HOME/.local/bin:$PATH"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
           for attempt in 1 2 3; do
-            echo "Installing Railway CLI v${RAILWAY_VERSION} (attempt $attempt/3)…"
-            if curl -fsSL https://railway.app/install.sh | bash -s -- -y -b "$HOME/.local/bin"; then
+            echo "Installing @railway/cli@${RAILWAY_VERSION} (attempt $attempt/3)…"
+            if npm install -g "@railway/cli@${RAILWAY_VERSION}"; then
               break
             fi
             sleep $((attempt * 10))
           done
-
-          if ! command -v railway >/dev/null 2>&1; then
-            echo "Railway install.sh failed; falling back to npm @railway/cli@4.17.1" >&2
-            npm install -g @railway/cli@4.17.1
-          fi
 
           railway --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,22 +266,13 @@ jobs:
 
           export RAILWAY_VERSION="4.18.1"
 
-          mkdir -p "$HOME/.local/bin"
-          export PATH="$HOME/.local/bin:$PATH"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
           for attempt in 1 2 3; do
-            echo "Installing Railway CLI v${RAILWAY_VERSION} (attempt $attempt/3)…"
-            if curl -fsSL https://railway.app/install.sh | bash -s -- -y -b "$HOME/.local/bin"; then
+            echo "Installing @railway/cli@${RAILWAY_VERSION} (attempt $attempt/3)…"
+            if npm install -g "@railway/cli@${RAILWAY_VERSION}"; then
               break
             fi
             sleep $((attempt * 10))
           done
-
-          if ! command -v railway >/dev/null 2>&1; then
-            echo "Railway install.sh failed; falling back to npm @railway/cli@4.17.1" >&2
-            npm install -g @railway/cli@4.17.1
-          fi
 
           railway --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,8 +264,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          export RAILWAY_VERSION="4.18.1"
-          railway_bin="$(npm config get prefix)/bin"
+          export RAILWAY_VERSION="4.18.2"
+          export npm_config_prefix="${RUNNER_TEMP}/railway-npm"
+          railway_bin="${npm_config_prefix}/bin"
+          mkdir -p "$railway_bin"
           export PATH="${railway_bin}:${PATH}"
           echo "$railway_bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,9 @@ jobs:
           set -euo pipefail
 
           export RAILWAY_VERSION="4.18.1"
+          railway_bin="$(npm config get prefix)/bin"
+          export PATH="${railway_bin}:${PATH}"
+          echo "$railway_bin" >> "$GITHUB_PATH"
 
           for attempt in 1 2 3; do
             echo "Installing @railway/cli@${RAILWAY_VERSION} (attempt $attempt/3)…"
@@ -273,6 +276,11 @@ jobs:
             fi
             sleep $((attempt * 10))
           done
+
+          if ! command -v railway >/dev/null 2>&1; then
+            echo "Failed to install Railway CLI (@railway/cli@${RAILWAY_VERSION}) after 3 attempts." >&2
+            exit 1
+          fi
 
           railway --version
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,22 +42,13 @@ jobs:
 
           export RAILWAY_VERSION="4.18.1"
 
-          mkdir -p "$HOME/.local/bin"
-          export PATH="$HOME/.local/bin:$PATH"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
           for attempt in 1 2 3; do
-            echo "Installing Railway CLI v${RAILWAY_VERSION} (attempt $attempt/3)…"
-            if curl -fsSL https://railway.app/install.sh | bash -s -- -y -b "$HOME/.local/bin"; then
+            echo "Installing @railway/cli@${RAILWAY_VERSION} (attempt $attempt/3)…"
+            if npm install -g "@railway/cli@${RAILWAY_VERSION}"; then
               break
             fi
             sleep $((attempt * 10))
           done
-
-          if ! command -v railway >/dev/null 2>&1; then
-            echo "Railway install.sh failed; falling back to npm @railway/cli@4.17.1" >&2
-            npm install -g @railway/cli@4.17.1
-          fi
 
           railway --version
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,9 @@ jobs:
           set -euo pipefail
 
           export RAILWAY_VERSION="4.18.1"
+          railway_bin="$(npm config get prefix)/bin"
+          export PATH="${railway_bin}:${PATH}"
+          echo "$railway_bin" >> "$GITHUB_PATH"
 
           for attempt in 1 2 3; do
             echo "Installing @railway/cli@${RAILWAY_VERSION} (attempt $attempt/3)…"
@@ -49,6 +52,11 @@ jobs:
             fi
             sleep $((attempt * 10))
           done
+
+          if ! command -v railway >/dev/null 2>&1; then
+            echo "Failed to install Railway CLI (@railway/cli@${RAILWAY_VERSION}) after 3 attempts." >&2
+            exit 1
+          fi
 
           railway --version
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,8 +40,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          export RAILWAY_VERSION="4.18.1"
-          railway_bin="$(npm config get prefix)/bin"
+          export RAILWAY_VERSION="4.18.2"
+          export npm_config_prefix="${RUNNER_TEMP}/railway-npm"
+          railway_bin="${npm_config_prefix}/bin"
+          mkdir -p "$railway_bin"
           export PATH="${railway_bin}:${PATH}"
           echo "$railway_bin" >> "$GITHUB_PATH"
 


### PR DESCRIPTION
## What

- Replace the unverified Railway `curl | bash` installer in CI and deploy workflows.
- Install the published `@railway/cli@4.18.2` package with bounded retries.

## Why

- Remove remote-script execution from privileged workflows and keep the installer deterministic.

## How

- Install the exact npm package version, add npm global bin to `PATH`, retry three times, and fail explicitly if `railway` is unavailable.
- Preserve the existing `railway --version` verification and deployment commands.

## Checklist

- [x] Workflow YAML parses successfully
- [x] Every embedded shell block passes `bash -n`
- [x] `@railway/cli@4.18.2` installs and reports the expected version
- [x] `git diff --check`

---

### Motivation

- CI and deploy workflows previously executed Railway's remote installer via `curl -fsSL https://railway.app/install.sh | bash`, which creates a supply-chain risk because the script runs unverified code in runners that hold deployment secrets. 
- The intent is to install the Railway CLI in CI for automated deploys while eliminating the unverified remote-script execution path.

### Description

- Replaced the unverified `curl|bash` installer with `npm install -g "@railway/cli@${RAILWAY_VERSION}"` in both `.github/workflows/ci.yml` and `.github/workflows/deploy.yml`.
- Removed the `$HOME/.local/bin` bootstrap and the `curl|bash` fallback logic while preserving the retry loop around the install step.
- Kept the `railway --version` verification step after installation to ensure the CLI is available for deploy steps.

### Testing

- Ran `git diff --check` to ensure no whitespace or patch issues and it succeeded.
- Verified the workflow diffs show the `curl|bash` lines removed and the `@railway/cli` `npm install -g` install lines added. 
- Reviewed the updated workflow files to confirm no remaining `curl|bash` installer usages were present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cc1569bbe48332a40a260f2733f99f)

## Summary by Sourcery

Replace Railway CLI installation in CI and deploy workflows with a pinned npm-based install and remove the curl|bash remote installer.

CI:
- Update CI workflow to install a specific @railway/cli version via npm with bounded retries and fail fast if installation does not succeed.

Deployment:
- Update deploy workflow to use a pinned @railway/cli npm installation instead of the remote install script, ensuring deterministic and verified CLI availability.