### PR TITLE
perf(convex): cut man-page and section-list read amplification

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -349,9 +349,10 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 
 ### Convex performance audit (post-v0.6.4)
 
-- [x] Section browse reads `manPageSearchDocuments` digests instead of full `manPages` rows.
 - [x] Parallelize related-page + distro-variant lookups on man page reads.
-- [x] Drop unused `manPages` indexes (`by_releaseId_and_name`, `by_releaseId_and_section_and_name`).
+- [x] Drop unused `manPages` index `by_releaseId_and_name` (covered by name+section compound index).
 - [x] Remove unused content-loading query exports (man pages go through `content.*` actions).
+- [x] Keep section browse on `manPages` (search docs are larger due to `searchText`/`snippetText`).
 - [ ] Optional follow-up: cursor pagination for deep `listSection` offsets (still offset-based API).
 - [ ] Optional follow-up: denormalize title/description onto `manPageLinks` to remove `getRelated` joins.
+- [ ] Optional follow-up: dedicated slim section-list digest table if insights show high bytes/doc.

--- a/PLAN.md
+++ b/PLAN.md
@@ -350,9 +350,13 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 ### Convex performance audit (post-v0.6.4)
 
 - [x] Parallelize related-page + distro-variant lookups on man page reads.
+- [x] Parallelize `pageReadModel` content + variants fan-out.
 - [x] Drop unused `manPages` index `by_releaseId_and_name` (covered by name+section compound index).
 - [x] Remove unused content-loading query exports (man pages go through `content.*` actions).
 - [x] Keep section browse on `manPages` (search docs are larger due to `searchText`/`snippetText`).
+- [x] Canonicalize legacy content-field readers in `convex/_legacyContent.ts`.
+- [x] Retire FTS `search_searchText` index; `searchText` is metadata-only for prefix/suggest.
+- [x] Cap `getRelated` fan-out before parallel page lookups; reuse search prefix helper in `suggest`.
 - [ ] Optional follow-up: cursor pagination for deep `listSection` offsets (still offset-based API).
 - [ ] Optional follow-up: denormalize title/description onto `manPageLinks` to remove `getRelated` joins.
 - [ ] Optional follow-up: dedicated slim section-list digest table if insights show high bytes/doc.

--- a/PLAN.md
+++ b/PLAN.md
@@ -346,3 +346,12 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 - [x] UI theme selection persisted via `bm-ui-theme` cookie (SSR-compatible).
 - [x] Documentation updated (SPEC.md, CHANGELOG.md).
 - [x] Tag `v0.6.4`
+
+### Convex performance audit (post-v0.6.4)
+
+- [x] Section browse reads `manPageSearchDocuments` digests instead of full `manPages` rows.
+- [x] Parallelize related-page + distro-variant lookups on man page reads.
+- [x] Drop unused `manPages` indexes (`by_releaseId_and_name`, `by_releaseId_and_section_and_name`).
+- [x] Remove unused content-loading query exports (man pages go through `content.*` actions).
+- [ ] Optional follow-up: cursor pagination for deep `listSection` offsets (still offset-based API).
+- [ ] Optional follow-up: denormalize title/description onto `manPageLinks` to remove `getRelated` joins.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2857,7 +2857,8 @@ Two Railway services:
    - Handles all web traffic (SSR + static assets)
    - Serves `/api/*` through Next.js route handlers backed by Convex queries/actions
    - Man page bodies load via `content.getManByName*` actions (file storage), not query-transaction JSON
-   - Section browse lists from indexed `manPages` rows (search docs keep heavier `searchText` payloads)
+   - Section browse lists from indexed `manPages` rows
+   - Public search is prefix/suggest only (Convex full-text search index retired; search docs store compact metadata)
    - Serves SEO endpoints directly (Next owns `robots.txt` + sitemaps)
    - Public domain: `betterman.sh`
    - Env: `NEXT_PUBLIC_CONVEX_URL` or `CONVEX_URL`, `BETTERMAN_DATASET_STAGE`, `NEXT_PUBLIC_SENTRY_DSN`, `NEXT_PUBLIC_PLAUSIBLE_DOMAIN`

--- a/SPEC.md
+++ b/SPEC.md
@@ -2857,7 +2857,7 @@ Two Railway services:
    - Handles all web traffic (SSR + static assets)
    - Serves `/api/*` through Next.js route handlers backed by Convex queries/actions
    - Man page bodies load via `content.getManByName*` actions (file storage), not query-transaction JSON
-   - Section browse lists from `manPageSearchDocuments` digests (not full `manPages` rows)
+   - Section browse lists from indexed `manPages` rows (search docs keep heavier `searchText` payloads)
    - Serves SEO endpoints directly (Next owns `robots.txt` + sitemaps)
    - Public domain: `betterman.sh`
    - Env: `NEXT_PUBLIC_CONVEX_URL` or `CONVEX_URL`, `BETTERMAN_DATASET_STAGE`, `NEXT_PUBLIC_SENTRY_DSN`, `NEXT_PUBLIC_PLAUSIBLE_DOMAIN`

--- a/SPEC.md
+++ b/SPEC.md
@@ -2855,7 +2855,9 @@ Two Railway services:
 
 1. **Next.js Service** (public-facing):
    - Handles all web traffic (SSR + static assets)
-   - Serves `/api/*` through Next.js route handlers backed by Convex queries/mutations
+   - Serves `/api/*` through Next.js route handlers backed by Convex queries/actions
+   - Man page bodies load via `content.getManByName*` actions (file storage), not query-transaction JSON
+   - Section browse lists from `manPageSearchDocuments` digests (not full `manPages` rows)
    - Serves SEO endpoints directly (Next owns `robots.txt` + sitemaps)
    - Public domain: `betterman.sh`
    - Env: `NEXT_PUBLIC_CONVEX_URL` or `CONVEX_URL`, `BETTERMAN_DATASET_STAGE`, `NEXT_PUBLIC_SENTRY_DSN`, `NEXT_PUBLIC_PLAUSIBLE_DOMAIN`

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as _releaseLookups from "../_releaseLookups.js";
 import type * as content from "../content.js";
 import type * as http from "../http.js";
 import type * as ingest from "../ingest.js";
@@ -23,6 +24,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  _releaseLookups: typeof _releaseLookups;
   content: typeof content;
   http: typeof http;
   ingest: typeof ingest;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as _legacyContent from "../_legacyContent.js";
 import type * as _releaseLookups from "../_releaseLookups.js";
 import type * as content from "../content.js";
 import type * as http from "../http.js";
@@ -24,6 +25,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  _legacyContent: typeof _legacyContent;
   _releaseLookups: typeof _releaseLookups;
   content: typeof content;
   http: typeof http;

--- a/convex/_legacyContent.ts
+++ b/convex/_legacyContent.ts
@@ -1,0 +1,100 @@
+import type { Doc } from "./_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
+import type { ManPageContentPayload } from "./lib";
+
+export type ContentJsonKind = keyof ManPageContentPayload;
+export type StoredContentFields = Record<ContentJsonKind, string | null>;
+export type ContentField = { kind: ContentJsonKind; value: string | undefined };
+
+export const CONTENT_KINDS: ContentJsonKind[] = [
+  "docJson",
+  "synopsisJson",
+  "optionsJson",
+  "seeAlsoJson",
+];
+
+type DbCtx = QueryCtx | MutationCtx;
+
+export async function readContentBlobField(
+  ctx: DbCtx,
+  blob: Doc<"manPageContentBlobs">,
+  kind: ContentJsonKind,
+): Promise<string | null> {
+  const inline = blob[kind];
+  if (typeof inline === "string") return inline;
+
+  const chunks = await ctx.db
+    .query("manPageContentBlobChunks")
+    .withIndex("by_blobId_and_kind_and_chunkIndex", (q) =>
+      q.eq("blobId", blob._id).eq("kind", kind),
+    )
+    .collect();
+  if (!chunks.length) return null;
+  return chunks
+    .sort((a, b) => a.chunkIndex - b.chunkIndex)
+    .map((chunk) => chunk.chunk)
+    .join("");
+}
+
+export async function readManPageContentField(
+  ctx: DbCtx,
+  content: Doc<"manPageContents">,
+  kind: ContentJsonKind,
+): Promise<string | null> {
+  const inline = content[kind];
+  if (typeof inline === "string") return inline;
+
+  const chunks = await ctx.db
+    .query("manPageContentChunks")
+    .withIndex("by_contentId_and_kind_and_chunkIndex", (q) =>
+      q.eq("contentId", content._id).eq("kind", kind),
+    )
+    .collect();
+  if (!chunks.length) return null;
+  return chunks
+    .sort((a, b) => a.chunkIndex - b.chunkIndex)
+    .map((chunk) => chunk.chunk)
+    .join("");
+}
+
+export async function readAllContentBlobFields(
+  ctx: DbCtx,
+  blob: Doc<"manPageContentBlobs">,
+): Promise<StoredContentFields> {
+  const entries = await Promise.all(
+    CONTENT_KINDS.map(async (kind) => [kind, await readContentBlobField(ctx, blob, kind)] as const),
+  );
+  return Object.fromEntries(entries) as StoredContentFields;
+}
+
+export async function readAllManPageContentFields(
+  ctx: DbCtx,
+  content: Doc<"manPageContents">,
+): Promise<StoredContentFields> {
+  const entries = await Promise.all(
+    CONTENT_KINDS.map(
+      async (kind) => [kind, await readManPageContentField(ctx, content, kind)] as const,
+    ),
+  );
+  return Object.fromEntries(entries) as StoredContentFields;
+}
+
+export async function readManPageContentFieldList(
+  ctx: DbCtx,
+  content: Doc<"manPageContents">,
+): Promise<ContentField[]> {
+  const fields = await readAllManPageContentFields(ctx, content);
+  return CONTENT_KINDS.map((kind) => ({
+    kind,
+    value: fields[kind] ?? undefined,
+  }));
+}
+
+export function contentFieldsChars(
+  fields: StoredContentFields | ContentField[],
+): number {
+  if (Array.isArray(fields)) {
+    return fields.reduce((total, field) => total + (field.value?.length ?? 0), 0);
+  }
+  return CONTENT_KINDS.reduce((total, kind) => total + (fields[kind]?.length ?? 0), 0);
+}

--- a/convex/_releaseLookups.ts
+++ b/convex/_releaseLookups.ts
@@ -1,6 +1,6 @@
 import type { QueryCtx } from "./_generated/server";
 import type { Doc, Id } from "./_generated/dataModel";
-import { DISTRO_ORDER, type DatasetStage, type Distro } from "./lib";
+import { DISTRO_ORDER, DISTROS, type DatasetStage, type Distro } from "./lib";
 
 export async function activeRelease(
   ctx: QueryCtx,
@@ -45,13 +45,13 @@ export async function variantsForPage(
     name: string;
     section: string;
   },
-): Promise<Array<{ distro: string; datasetReleaseId: string; contentSha256: string }>> {
+): Promise<Array<{ distro: Distro; datasetReleaseId: string; contentSha256: string }>> {
   const active = await ctx.db
     .query("activeReleases")
     .withIndex("by_stage_and_locale_and_distro", (q) =>
       q.eq("stage", args.stage).eq("locale", args.locale),
     )
-    .take(20);
+    .take(DISTROS.length);
 
   const variants = (
     await Promise.all(

--- a/convex/_releaseLookups.ts
+++ b/convex/_releaseLookups.ts
@@ -1,0 +1,79 @@
+import type { QueryCtx } from "./_generated/server";
+import type { Doc, Id } from "./_generated/dataModel";
+import { DISTRO_ORDER, type DatasetStage, type Distro } from "./lib";
+
+export async function activeRelease(
+  ctx: QueryCtx,
+  args: { stage: DatasetStage; distro: Distro; locale?: string },
+): Promise<Doc<"datasetReleases"> | null> {
+  const active = await ctx.db
+    .query("activeReleases")
+    .withIndex("by_stage_and_locale_and_distro", (q) =>
+      q.eq("stage", args.stage).eq("locale", args.locale ?? "en").eq("distro", args.distro),
+    )
+    .unique();
+  if (!active) return null;
+  return await ctx.db.get(active.releaseId);
+}
+
+export async function requireActiveRelease(
+  ctx: QueryCtx,
+  args: { stage: DatasetStage; distro: Distro; locale?: string },
+): Promise<Doc<"datasetReleases">> {
+  const release = await activeRelease(ctx, args);
+  if (!release) throw new Error("ACTIVE_RELEASE_NOT_FOUND");
+  return release;
+}
+
+export async function pageByNameAndSection(
+  ctx: QueryCtx,
+  args: { releaseId: Id<"datasetReleases">; name: string; section: string },
+): Promise<Doc<"manPages"> | null> {
+  return await ctx.db
+    .query("manPages")
+    .withIndex("by_releaseId_and_name_and_section", (q) =>
+      q.eq("releaseId", args.releaseId).eq("name", args.name).eq("section", args.section),
+    )
+    .unique();
+}
+
+export async function variantsForPage(
+  ctx: QueryCtx,
+  args: {
+    stage: DatasetStage;
+    locale: string;
+    name: string;
+    section: string;
+  },
+): Promise<Array<{ distro: string; datasetReleaseId: string; contentSha256: string }>> {
+  const active = await ctx.db
+    .query("activeReleases")
+    .withIndex("by_stage_and_locale_and_distro", (q) =>
+      q.eq("stage", args.stage).eq("locale", args.locale),
+    )
+    .take(20);
+
+  const variants = (
+    await Promise.all(
+      active.map(async (item) => {
+        const page = await pageByNameAndSection(ctx, {
+          releaseId: item.releaseId,
+          name: args.name,
+          section: args.section,
+        });
+        if (!page) return null;
+        return {
+          distro: item.distro,
+          datasetReleaseId: item.datasetReleaseId,
+          contentSha256: page.contentSha256,
+        };
+      }),
+    )
+  ).filter((variant): variant is NonNullable<typeof variant> => variant !== null);
+
+  variants.sort((a, b) => {
+    const order = (DISTRO_ORDER[a.distro] ?? 99) - (DISTRO_ORDER[b.distro] ?? 99);
+    return order || a.distro.localeCompare(b.distro);
+  });
+  return variants;
+}

--- a/convex/content.ts
+++ b/convex/content.ts
@@ -18,13 +18,18 @@ import {
   pageResponse,
 } from "./lib";
 import {
+  CONTENT_KINDS,
+  contentFieldsChars,
+  readAllContentBlobFields,
+  readAllManPageContentFields,
+  type StoredContentFields,
+} from "./_legacyContent";
+import {
   pageByNameAndSection,
   requireActiveRelease,
   variantsForPage,
 } from "./_releaseLookups";
 
-type ContentJsonKind = keyof ManPageContentPayload;
-type StoredContentFields = Record<ContentJsonKind, string | null>;
 type StorageMigrationTarget = "blobs" | "contents";
 type BlobStorageMigrationItem = {
   blobId: Id<"manPageContentBlobs">;
@@ -61,20 +66,10 @@ type StorageMigrationBatchResult = {
 
 const DEFAULT_STORAGE_MIGRATION_LIMIT = 5;
 const MAX_STORAGE_MIGRATION_LIMIT = 25;
-const CONTENT_KINDS: ContentJsonKind[] = [
-  "docJson",
-  "synopsisJson",
-  "optionsJson",
-  "seeAlsoJson",
-];
 
 function bounded(value: number | undefined, fallback: number, max: number): number {
   if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
   return Math.max(1, Math.min(Math.floor(value), max));
-}
-
-function contentFieldsChars(fields: StoredContentFields): number {
-  return CONTENT_KINDS.reduce((total, kind) => total + (fields[kind]?.length ?? 0), 0);
 }
 
 function storagePayload(args: {
@@ -127,74 +122,6 @@ async function readStoredContent(
   }
 }
 
-async function contentBlobJsonField(
-  ctx: QueryCtx,
-  blob: Doc<"manPageContentBlobs">,
-  kind: ContentJsonKind,
-): Promise<string | null> {
-  const inline = blob[kind];
-  if (typeof inline === "string") return inline;
-
-  const chunks = await ctx.db
-    .query("manPageContentBlobChunks")
-    .withIndex("by_blobId_and_kind_and_chunkIndex", (q) =>
-      q.eq("blobId", blob._id).eq("kind", kind),
-    )
-    .collect();
-  if (!chunks.length) return null;
-  return chunks
-    .sort((a, b) => a.chunkIndex - b.chunkIndex)
-    .map((chunk) => chunk.chunk)
-    .join("");
-}
-
-async function contentJsonField(
-  ctx: QueryCtx,
-  content: Doc<"manPageContents">,
-  kind: ContentJsonKind,
-): Promise<string | null> {
-  const inline = content[kind];
-  if (typeof inline === "string") return inline;
-
-  const chunks = await ctx.db
-    .query("manPageContentChunks")
-    .withIndex("by_contentId_and_kind_and_chunkIndex", (q) =>
-      q.eq("contentId", content._id).eq("kind", kind),
-    )
-    .collect();
-  if (!chunks.length) return null;
-  return chunks
-    .sort((a, b) => a.chunkIndex - b.chunkIndex)
-    .map((chunk) => chunk.chunk)
-    .join("");
-}
-
-async function legacyBlobFields(
-  ctx: QueryCtx,
-  blob: Doc<"manPageContentBlobs">,
-): Promise<StoredContentFields> {
-  const [docJson, synopsisJson, optionsJson, seeAlsoJson] = await Promise.all([
-    contentBlobJsonField(ctx, blob, "docJson"),
-    contentBlobJsonField(ctx, blob, "synopsisJson"),
-    contentBlobJsonField(ctx, blob, "optionsJson"),
-    contentBlobJsonField(ctx, blob, "seeAlsoJson"),
-  ]);
-  return { docJson, synopsisJson, optionsJson, seeAlsoJson };
-}
-
-async function legacyContentFields(
-  ctx: QueryCtx,
-  content: Doc<"manPageContents">,
-): Promise<StoredContentFields> {
-  const [docJson, synopsisJson, optionsJson, seeAlsoJson] = await Promise.all([
-    contentJsonField(ctx, content, "docJson"),
-    contentJsonField(ctx, content, "synopsisJson"),
-    contentJsonField(ctx, content, "optionsJson"),
-    contentJsonField(ctx, content, "seeAlsoJson"),
-  ]);
-  return { docJson, synopsisJson, optionsJson, seeAlsoJson };
-}
-
 async function deleteContentBlobChunks(ctx: MutationCtx, blobId: Id<"manPageContentBlobs">) {
   let deleted = 0;
   for (const kind of CONTENT_KINDS) {
@@ -242,7 +169,7 @@ async function contentPointer(ctx: QueryCtx, pageId: Id<"manPages">) {
       return { storageId: blob.storageId, fields: null };
     }
     if (blob) {
-      return { storageId: null, fields: await legacyBlobFields(ctx, blob) };
+      return { storageId: null, fields: await readAllContentBlobFields(ctx, blob) };
     }
   }
 
@@ -250,7 +177,7 @@ async function contentPointer(ctx: QueryCtx, pageId: Id<"manPages">) {
     return { storageId: content.storageId, fields: null };
   }
 
-  return { storageId: null, fields: await legacyContentFields(ctx, content) };
+  return { storageId: null, fields: await readAllManPageContentFields(ctx, content) };
 }
 
 export const readContentBlobStorageMigrationBatch = internalQuery({
@@ -272,7 +199,7 @@ export const readContentBlobStorageMigrationBatch = internalQuery({
         alreadyStored += 1;
         continue;
       }
-      const fields = await legacyBlobFields(ctx, blob);
+      const fields = await readAllContentBlobFields(ctx, blob);
       const legacyChars = contentFieldsChars(fields);
       if (!legacyChars) {
         emptyLegacy += 1;
@@ -324,7 +251,7 @@ export const readPageContentStorageMigrationBatch = internalQuery({
         alreadyStored += 1;
         continue;
       }
-      const fields = await legacyContentFields(ctx, content);
+      const fields = await readAllManPageContentFields(ctx, content);
       const legacyChars = contentFieldsChars(fields);
       if (!legacyChars) {
         emptyLegacy += 1;
@@ -479,14 +406,16 @@ async function pageReadModel(
   ctx: QueryCtx,
   args: { stage: DatasetStage; release: Doc<"datasetReleases">; page: Doc<"manPages"> },
 ) {
-  const content = await contentPointer(ctx, args.page._id);
+  const [content, variants] = await Promise.all([
+    contentPointer(ctx, args.page._id),
+    variantsForPage(ctx, {
+      stage: args.stage,
+      locale: args.release.locale,
+      name: args.page.name,
+      section: args.page.section,
+    }),
+  ]);
   if (!content) return null;
-  const variants = await variantsForPage(ctx, {
-    stage: args.stage,
-    locale: args.release.locale,
-    name: args.page.name,
-    section: args.page.section,
-  });
   return {
     release: args.release,
     page: args.page,

--- a/convex/content.ts
+++ b/convex/content.ts
@@ -12,13 +12,16 @@ import type { Doc, Id } from "./_generated/dataModel";
 import { datasetStageValidator, distroValidator } from "./schema";
 import {
   type DatasetStage,
-  DISTRO_ORDER,
-  type Distro,
   type ManPageContentPayload,
   normalizeName,
   normalizeSection,
   pageResponse,
 } from "./lib";
+import {
+  pageByNameAndSection,
+  requireActiveRelease,
+  variantsForPage,
+} from "./_releaseLookups";
 
 type ContentJsonKind = keyof ManPageContentPayload;
 type StoredContentFields = Record<ContentJsonKind, string | null>;
@@ -124,79 +127,6 @@ async function readStoredContent(
   }
 }
 
-async function activeRelease(
-  ctx: QueryCtx,
-  args: { stage: DatasetStage; distro: Distro; locale?: string },
-): Promise<Doc<"datasetReleases"> | null> {
-  const active = await ctx.db
-    .query("activeReleases")
-    .withIndex("by_stage_and_locale_and_distro", (q) =>
-      q.eq("stage", args.stage).eq("locale", args.locale ?? "en").eq("distro", args.distro),
-    )
-    .unique();
-  if (!active) return null;
-  return await ctx.db.get(active.releaseId);
-}
-
-async function requireActiveRelease(
-  ctx: QueryCtx,
-  args: { stage: DatasetStage; distro: Distro; locale?: string },
-): Promise<Doc<"datasetReleases">> {
-  const release = await activeRelease(ctx, args);
-  if (!release) throw new Error("ACTIVE_RELEASE_NOT_FOUND");
-  return release;
-}
-
-async function pageByNameAndSection(
-  ctx: QueryCtx,
-  args: { releaseId: Id<"datasetReleases">; name: string; section: string },
-): Promise<Doc<"manPages"> | null> {
-  return await ctx.db
-    .query("manPages")
-    .withIndex("by_releaseId_and_name_and_section", (q) =>
-      q.eq("releaseId", args.releaseId).eq("name", args.name).eq("section", args.section),
-    )
-    .unique();
-}
-
-async function variantsForPage(
-  ctx: QueryCtx,
-  args: {
-    stage: DatasetStage;
-    locale: string;
-    name: string;
-    section: string;
-  },
-): Promise<Array<{ distro: string; datasetReleaseId: string; contentSha256: string }>> {
-  const active = await ctx.db
-    .query("activeReleases")
-    .withIndex("by_stage_and_locale_and_distro", (q) =>
-      q.eq("stage", args.stage).eq("locale", args.locale),
-    )
-    .take(20);
-
-  const variants: Array<{ distro: string; datasetReleaseId: string; contentSha256: string }> = [];
-  for (const item of active) {
-    const page = await pageByNameAndSection(ctx, {
-      releaseId: item.releaseId,
-      name: args.name,
-      section: args.section,
-    });
-    if (!page) continue;
-    variants.push({
-      distro: item.distro,
-      datasetReleaseId: item.datasetReleaseId,
-      contentSha256: page.contentSha256,
-    });
-  }
-
-  variants.sort((a, b) => {
-    const order = (DISTRO_ORDER[a.distro] ?? 99) - (DISTRO_ORDER[b.distro] ?? 99);
-    return order || a.distro.localeCompare(b.distro);
-  });
-  return variants;
-}
-
 async function contentBlobJsonField(
   ctx: QueryCtx,
   blob: Doc<"manPageContentBlobs">,
@@ -243,24 +173,26 @@ async function legacyBlobFields(
   ctx: QueryCtx,
   blob: Doc<"manPageContentBlobs">,
 ): Promise<StoredContentFields> {
-  return {
-    docJson: await contentBlobJsonField(ctx, blob, "docJson"),
-    synopsisJson: await contentBlobJsonField(ctx, blob, "synopsisJson"),
-    optionsJson: await contentBlobJsonField(ctx, blob, "optionsJson"),
-    seeAlsoJson: await contentBlobJsonField(ctx, blob, "seeAlsoJson"),
-  };
+  const [docJson, synopsisJson, optionsJson, seeAlsoJson] = await Promise.all([
+    contentBlobJsonField(ctx, blob, "docJson"),
+    contentBlobJsonField(ctx, blob, "synopsisJson"),
+    contentBlobJsonField(ctx, blob, "optionsJson"),
+    contentBlobJsonField(ctx, blob, "seeAlsoJson"),
+  ]);
+  return { docJson, synopsisJson, optionsJson, seeAlsoJson };
 }
 
 async function legacyContentFields(
   ctx: QueryCtx,
   content: Doc<"manPageContents">,
 ): Promise<StoredContentFields> {
-  return {
-    docJson: await contentJsonField(ctx, content, "docJson"),
-    synopsisJson: await contentJsonField(ctx, content, "synopsisJson"),
-    optionsJson: await contentJsonField(ctx, content, "optionsJson"),
-    seeAlsoJson: await contentJsonField(ctx, content, "seeAlsoJson"),
-  };
+  const [docJson, synopsisJson, optionsJson, seeAlsoJson] = await Promise.all([
+    contentJsonField(ctx, content, "docJson"),
+    contentJsonField(ctx, content, "synopsisJson"),
+    contentJsonField(ctx, content, "optionsJson"),
+    contentJsonField(ctx, content, "seeAlsoJson"),
+  ]);
+  return { docJson, synopsisJson, optionsJson, seeAlsoJson };
 }
 
 async function deleteContentBlobChunks(ctx: MutationCtx, blobId: Id<"manPageContentBlobs">) {
@@ -310,15 +242,7 @@ async function contentPointer(ctx: QueryCtx, pageId: Id<"manPages">) {
       return { storageId: blob.storageId, fields: null };
     }
     if (blob) {
-      return {
-        storageId: null,
-        fields: {
-          docJson: await contentBlobJsonField(ctx, blob, "docJson"),
-          synopsisJson: await contentBlobJsonField(ctx, blob, "synopsisJson"),
-          optionsJson: await contentBlobJsonField(ctx, blob, "optionsJson"),
-          seeAlsoJson: await contentBlobJsonField(ctx, blob, "seeAlsoJson"),
-        },
-      };
+      return { storageId: null, fields: await legacyBlobFields(ctx, blob) };
     }
   }
 
@@ -326,15 +250,7 @@ async function contentPointer(ctx: QueryCtx, pageId: Id<"manPages">) {
     return { storageId: content.storageId, fields: null };
   }
 
-  return {
-    storageId: null,
-    fields: {
-      docJson: await contentJsonField(ctx, content, "docJson"),
-      synopsisJson: await contentJsonField(ctx, content, "synopsisJson"),
-      optionsJson: await contentJsonField(ctx, content, "optionsJson"),
-      seeAlsoJson: await contentJsonField(ctx, content, "seeAlsoJson"),
-    },
-  };
+  return { storageId: null, fields: await legacyContentFields(ctx, content) };
 }
 
 export const readContentBlobStorageMigrationBatch = internalQuery({

--- a/convex/lib.ts
+++ b/convex/lib.ts
@@ -202,28 +202,19 @@ function searchMetadataFields(page: {
   ];
 }
 
+/** Compact search-doc text for prefix/suggest metadata only (FTS body retired). */
 export function compactManPageSearchText(page: {
   name: string;
   section: string;
   title: string;
   description: string;
-  searchText: string;
+  searchText?: string;
   snippetText: string;
 }): string {
-  const metadataFields = searchMetadataFields(page);
-  const metadata = new Set(metadataFields.map((field) => normalizeSearchDocumentText(field)));
-  const body = page.searchText
-    .split("\n")
-    .map((line) => normalizeSearchDocumentText(line))
-    .filter((line) => line && !metadata.has(line))
-    .join(" ");
-  const fields = [
-    ...metadataFields,
-    truncateText(body, MAX_SEARCH_TEXT_CHARS),
-  ];
+  void page.searchText;
   const seen = new Set<string>();
   const parts = [];
-  for (const field of fields) {
+  for (const field of searchMetadataFields(page)) {
     const normalized = normalizeSearchDocumentText(field);
     if (!normalized || seen.has(normalized)) continue;
     seen.add(normalized);

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -160,11 +160,17 @@ async function legacyContentFields(
   ctx: QueryCtx | MutationCtx,
   content: Doc<"manPageContents">,
 ): Promise<ContentField[]> {
+  const [docJson, synopsisJson, optionsJson, seeAlsoJson] = await Promise.all([
+    legacyContentJsonField(ctx, content, "docJson"),
+    legacyContentJsonField(ctx, content, "synopsisJson"),
+    legacyContentJsonField(ctx, content, "optionsJson"),
+    legacyContentJsonField(ctx, content, "seeAlsoJson"),
+  ]);
   return [
-    { kind: "docJson", value: await legacyContentJsonField(ctx, content, "docJson") },
-    { kind: "synopsisJson", value: await legacyContentJsonField(ctx, content, "synopsisJson") },
-    { kind: "optionsJson", value: await legacyContentJsonField(ctx, content, "optionsJson") },
-    { kind: "seeAlsoJson", value: await legacyContentJsonField(ctx, content, "seeAlsoJson") },
+    { kind: "docJson", value: docJson },
+    { kind: "synopsisJson", value: synopsisJson },
+    { kind: "optionsJson", value: optionsJson },
+    { kind: "seeAlsoJson", value: seeAlsoJson },
   ];
 }
 

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -8,6 +8,12 @@ import {
   MAX_SNIPPET_TEXT_CHARS,
   truncateText,
 } from "./lib";
+import {
+  type ContentField,
+  type ContentJsonKind,
+  contentFieldsChars,
+  readManPageContentFieldList,
+} from "./_legacyContent";
 
 const DEFAULT_RELEASE_LIMIT = 5;
 const MAX_RELEASE_LIMIT = 10;
@@ -24,9 +30,6 @@ const MAX_ORPHAN_BLOB_LIMIT = 100;
 const DEFAULT_STORAGE_STATS_LIMIT = 25;
 const MAX_STORAGE_STATS_LIMIT = 100;
 const CONTENT_CHUNK_CHARS = 400_000;
-
-type ContentJsonKind = "docJson" | "synopsisJson" | "optionsJson" | "seeAlsoJson";
-type ContentField = { kind: ContentJsonKind; value: string | undefined };
 
 type ReleaseChildTable =
   | "releaseSectionStats"
@@ -133,49 +136,6 @@ function splitContentFields(contentFields: ContentField[]): {
   }
 
   return { inlinePayload, chunkedFields };
-}
-
-async function legacyContentJsonField(
-  ctx: QueryCtx | MutationCtx,
-  content: Doc<"manPageContents">,
-  kind: ContentJsonKind,
-): Promise<string | undefined> {
-  const inline = content[kind];
-  if (typeof inline === "string") return inline;
-
-  const chunks = await ctx.db
-    .query("manPageContentChunks")
-    .withIndex("by_contentId_and_kind_and_chunkIndex", (q) =>
-      q.eq("contentId", content._id).eq("kind", kind),
-    )
-    .collect();
-  if (!chunks.length) return undefined;
-  return chunks
-    .sort((a, b) => a.chunkIndex - b.chunkIndex)
-    .map((chunk) => chunk.chunk)
-    .join("");
-}
-
-async function legacyContentFields(
-  ctx: QueryCtx | MutationCtx,
-  content: Doc<"manPageContents">,
-): Promise<ContentField[]> {
-  const [docJson, synopsisJson, optionsJson, seeAlsoJson] = await Promise.all([
-    legacyContentJsonField(ctx, content, "docJson"),
-    legacyContentJsonField(ctx, content, "synopsisJson"),
-    legacyContentJsonField(ctx, content, "optionsJson"),
-    legacyContentJsonField(ctx, content, "seeAlsoJson"),
-  ]);
-  return [
-    { kind: "docJson", value: docJson },
-    { kind: "synopsisJson", value: synopsisJson },
-    { kind: "optionsJson", value: optionsJson },
-    { kind: "seeAlsoJson", value: seeAlsoJson },
-  ];
-}
-
-function contentFieldsChars(fields: ContentField[]): number {
-  return fields.reduce((total, field) => total + (field.value?.length ?? 0), 0);
 }
 
 async function insertContentBlobChunks(
@@ -714,7 +674,7 @@ export const dedupePageContentBatch = internalMutation({
         continue;
       }
 
-      const fields = await legacyContentFields(ctx, content);
+      const fields = await readManPageContentFieldList(ctx, content);
       const legacyChars = contentFieldsChars(fields);
       if (!legacyChars) {
         missingContent += 1;

--- a/convex/queries.ts
+++ b/convex/queries.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
-import { query } from "./_generated/server";
+import { query, type QueryCtx } from "./_generated/server";
+import type { Doc, Id } from "./_generated/dataModel";
 import { datasetStageValidator, distroValidator } from "./schema";
 import {
   deterministicSnippet,
@@ -24,12 +25,42 @@ const MAX_SEARCH_OFFSET = 200;
 const MAX_SECTION_LIMIT = 500;
 const MAX_SECTION_OFFSET = 5_000;
 const SITEMAP_CHUNK_ITEMS = 5_000;
-const MAX_RELATED_LINKS = 50;
-const MAX_RELATED_ITEMS = 50;
+const MAX_RELATED = 50;
 
 function boundedInt(value: number, min: number, max: number): number {
   if (!Number.isFinite(value)) return min;
   return Math.max(min, Math.min(Math.floor(value), max));
+}
+
+async function searchDocsByNamePrefix(
+  ctx: QueryCtx,
+  args: {
+    releaseId: Id<"datasetReleases">;
+    section: string | null;
+    prefix: string;
+    takeCount: number;
+  },
+): Promise<Array<Doc<"manPageSearchDocuments">>> {
+  const upper = prefixUpperBound(args.prefix);
+  if (args.section !== null) {
+    const section = args.section;
+    return await ctx.db
+      .query("manPageSearchDocuments")
+      .withIndex("by_releaseId_and_section_and_nameNorm", (q) =>
+        q
+          .eq("releaseId", args.releaseId)
+          .eq("section", section)
+          .gte("nameNorm", args.prefix)
+          .lt("nameNorm", upper),
+      )
+      .take(args.takeCount);
+  }
+  return await ctx.db
+    .query("manPageSearchDocuments")
+    .withIndex("by_releaseId_and_nameNorm", (q) =>
+      q.eq("releaseId", args.releaseId).gte("nameNorm", args.prefix).lt("nameNorm", upper),
+    )
+    .take(args.takeCount);
 }
 
 export const getInfo = query({
@@ -101,10 +132,11 @@ export const listSection = query({
       .unique();
     if (!stat) return null;
 
-    // Prefer search digests over manPages: same list fields, smaller rows.
+    // Prefer manPages over search docs: search rows carry searchText/snippetText
+    // payloads that are larger than the list fields this endpoint returns.
     const pages = await ctx.db
-      .query("manPageSearchDocuments")
-      .withIndex("by_releaseId_and_section_and_nameNorm", (q) =>
+      .query("manPages")
+      .withIndex("by_releaseId_and_section_and_name", (q) =>
         q.eq("releaseId", release._id).eq("section", section),
       )
       .take(offset + limit);
@@ -149,13 +181,13 @@ export const getRelated = query({
         .withIndex("by_fromPageId_and_linkType", (q) =>
           q.eq("fromPageId", page._id).eq("linkType", "see_also"),
         )
-        .take(MAX_RELATED_LINKS),
+        .take(MAX_RELATED),
       ctx.db
         .query("manPageLinks")
         .withIndex("by_fromPageId_and_linkType", (q) =>
           q.eq("fromPageId", page._id).eq("linkType", "xref"),
         )
-        .take(MAX_RELATED_LINKS),
+        .take(MAX_RELATED),
     ]);
 
     const uniqueLinks = [];
@@ -165,7 +197,6 @@ export const getRelated = query({
       if (seen.has(key)) continue;
       seen.add(key);
       uniqueLinks.push(link);
-      if (uniqueLinks.length >= MAX_RELATED_ITEMS) break;
     }
 
     const linkedPages = await Promise.all(
@@ -187,26 +218,17 @@ export const getRelated = query({
         title: linkedPage.title,
         description: linkedPage.description,
       });
-      if (items.length >= MAX_RELATED_ITEMS) break;
+      if (items.length >= MAX_RELATED) break;
     }
 
     return { items };
   },
 });
 
-type RankedSearchDocument = {
-  _id: string;
-  name: string;
-  nameNorm: string;
-  section: string;
-  title: string;
-  description: string;
-  snippetText: string;
-  rank: number;
-};
+type RankedSearchDocument = Doc<"manPageSearchDocuments"> & { rank: number };
 
 function rankSearchDocument(
-  doc: { nameNorm: string; descNorm: string },
+  doc: Pick<Doc<"manPageSearchDocuments">, "nameNorm" | "descNorm">,
   queryNorm: string,
   index: number,
 ): number {
@@ -249,26 +271,12 @@ export const search = query({
     const prefixDocs = (
       await Promise.all(
         prefixQueries.map((prefix) =>
-          section
-            ? ctx.db
-                .query("manPageSearchDocuments")
-                .withIndex("by_releaseId_and_section_and_nameNorm", (q) =>
-                  q
-                    .eq("releaseId", release._id)
-                    .eq("section", section)
-                    .gte("nameNorm", prefix)
-                    .lt("nameNorm", prefixUpperBound(prefix)),
-                )
-                .take(takeCount)
-            : ctx.db
-                .query("manPageSearchDocuments")
-                .withIndex("by_releaseId_and_nameNorm", (q) =>
-                  q
-                    .eq("releaseId", release._id)
-                    .gte("nameNorm", prefix)
-                    .lt("nameNorm", prefixUpperBound(prefix)),
-                )
-                .take(takeCount),
+          searchDocsByNamePrefix(ctx, {
+            releaseId: release._id,
+            section,
+            prefix,
+            takeCount,
+          }),
         ),
       )
     ).flat();
@@ -277,18 +285,7 @@ export const search = query({
     prefixDocs.forEach((doc, index) => {
       const current = ranked.get(doc._id);
       const rank = rankSearchDocument(doc, queryNorm, index);
-      if (!current || rank > current.rank) {
-        ranked.set(doc._id, {
-          _id: doc._id,
-          name: doc.name,
-          nameNorm: doc.nameNorm,
-          section: doc.section,
-          title: doc.title,
-          description: doc.description,
-          snippetText: doc.snippetText,
-          rank,
-        });
-      }
+      if (!current || rank > current.rank) ranked.set(doc._id, { ...doc, rank });
     });
 
     const ordered = [...ranked.values()].sort((a, b) => {

--- a/convex/queries.ts
+++ b/convex/queries.ts
@@ -190,6 +190,8 @@ export const getRelated = query({
         .take(MAX_RELATED),
     ]);
 
+    // Deduplicate across see_also + xref (up to 2 * MAX_RELATED candidates), then
+    // resolve in parallel and keep filling until MAX_RELATED valid pages exist.
     const uniqueLinks = [];
     const seen = new Set<string>();
     for (const link of [...seeAlso, ...xrefs]) {
@@ -197,7 +199,6 @@ export const getRelated = query({
       if (seen.has(key)) continue;
       seen.add(key);
       uniqueLinks.push(link);
-      if (uniqueLinks.length >= MAX_RELATED) break;
     }
 
     const linkedPages = await Promise.all(
@@ -210,16 +211,19 @@ export const getRelated = query({
       ),
     );
 
-    return {
-      items: linkedPages
-        .filter((linkedPage): linkedPage is NonNullable<typeof linkedPage> => linkedPage !== null)
-        .map((linkedPage) => ({
-          name: linkedPage.name,
-          section: linkedPage.section,
-          title: linkedPage.title,
-          description: linkedPage.description,
-        })),
-    };
+    const items = [];
+    for (const linkedPage of linkedPages) {
+      if (!linkedPage) continue;
+      items.push({
+        name: linkedPage.name,
+        section: linkedPage.section,
+        title: linkedPage.title,
+        description: linkedPage.description,
+      });
+      if (items.length >= MAX_RELATED) break;
+    }
+
+    return { items };
   },
 });
 

--- a/convex/queries.ts
+++ b/convex/queries.ts
@@ -1,23 +1,22 @@
 import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
-import { query, type QueryCtx } from "./_generated/server";
-import type { Doc, Id } from "./_generated/dataModel";
+import { query } from "./_generated/server";
 import { datasetStageValidator, distroValidator } from "./schema";
 import {
   deterministicSnippet,
-  type DatasetStage,
-  DISTRO_ORDER,
   DISTROS,
-  type Distro,
-  type ManPageContentPayload,
   normalizeName,
   normalizeSection,
-  pageResponse,
   prefixUpperBound,
   releasePackageManifest,
   sectionLabel,
   sectionSortKey,
 } from "./lib";
+import {
+  activeRelease,
+  pageByNameAndSection,
+  requireActiveRelease,
+} from "./_releaseLookups";
 
 const SITEMAP_URLS_PER_FILE = 10_000;
 const MAX_SEARCH_LIMIT = 50;
@@ -25,161 +24,12 @@ const MAX_SEARCH_OFFSET = 200;
 const MAX_SECTION_LIMIT = 500;
 const MAX_SECTION_OFFSET = 5_000;
 const SITEMAP_CHUNK_ITEMS = 5_000;
-type ContentJsonKind = keyof ManPageContentPayload;
+const MAX_RELATED_LINKS = 50;
+const MAX_RELATED_ITEMS = 50;
 
 function boundedInt(value: number, min: number, max: number): number {
   if (!Number.isFinite(value)) return min;
   return Math.max(min, Math.min(Math.floor(value), max));
-}
-
-function shouldUseFullTextSearch(args: {
-  queryNorm: string;
-  prefixCount: number;
-  offset: number;
-  limit: number;
-}): boolean {
-  void args;
-  // Full-text search currently reads the whole text index per query in production.
-  // Keep public search prefix-only until there is a cheaper summary/search table.
-  return false;
-}
-
-async function activeRelease(
-  ctx: QueryCtx,
-  args: { stage: DatasetStage; distro: Distro; locale?: string },
-): Promise<Doc<"datasetReleases"> | null> {
-  const active = await ctx.db
-    .query("activeReleases")
-    .withIndex("by_stage_and_locale_and_distro", (q) =>
-      q.eq("stage", args.stage).eq("locale", args.locale ?? "en").eq("distro", args.distro),
-    )
-    .unique();
-  if (!active) return null;
-  return await ctx.db.get(active.releaseId);
-}
-
-async function requireActiveRelease(
-  ctx: QueryCtx,
-  args: { stage: DatasetStage; distro: Distro; locale?: string },
-): Promise<Doc<"datasetReleases">> {
-  const release = await activeRelease(ctx, args);
-  if (!release) throw new Error("ACTIVE_RELEASE_NOT_FOUND");
-  return release;
-}
-
-async function pageContent(
-  ctx: QueryCtx,
-  pageId: Id<"manPages">,
-): Promise<ManPageContentPayload | null> {
-  const content = await ctx.db
-    .query("manPageContents")
-    .withIndex("by_pageId", (q) => q.eq("pageId", pageId))
-    .unique();
-  if (!content) return null;
-
-  return {
-    docJson: await contentJsonField(ctx, content, "docJson"),
-    synopsisJson: await contentJsonField(ctx, content, "synopsisJson"),
-    optionsJson: await contentJsonField(ctx, content, "optionsJson"),
-    seeAlsoJson: await contentJsonField(ctx, content, "seeAlsoJson"),
-  };
-}
-
-async function contentJsonField(
-  ctx: QueryCtx,
-  content: Doc<"manPageContents">,
-  kind: ContentJsonKind,
-): Promise<string | undefined> {
-  if (content.blobId) {
-    const blob = await ctx.db.get(content.blobId);
-    if (blob) return await contentBlobJsonField(ctx, blob, kind);
-  }
-
-  const inline = content[kind];
-  if (typeof inline === "string") return inline;
-
-  const chunks = await ctx.db
-    .query("manPageContentChunks")
-    .withIndex("by_contentId_and_kind_and_chunkIndex", (q) =>
-      q.eq("contentId", content._id).eq("kind", kind),
-    )
-    .collect();
-  if (!chunks.length) return undefined;
-  return chunks
-    .sort((a, b) => a.chunkIndex - b.chunkIndex)
-    .map((chunk) => chunk.chunk)
-    .join("");
-}
-
-async function contentBlobJsonField(
-  ctx: QueryCtx,
-  blob: Doc<"manPageContentBlobs">,
-  kind: ContentJsonKind,
-): Promise<string | undefined> {
-  const inline = blob[kind];
-  if (typeof inline === "string") return inline;
-
-  const chunks = await ctx.db
-    .query("manPageContentBlobChunks")
-    .withIndex("by_blobId_and_kind_and_chunkIndex", (q) =>
-      q.eq("blobId", blob._id).eq("kind", kind),
-    )
-    .collect();
-  if (!chunks.length) return undefined;
-  return chunks
-    .sort((a, b) => a.chunkIndex - b.chunkIndex)
-    .map((chunk) => chunk.chunk)
-    .join("");
-}
-
-async function pageByNameAndSection(
-  ctx: QueryCtx,
-  args: { releaseId: Id<"datasetReleases">; name: string; section: string },
-): Promise<Doc<"manPages"> | null> {
-  return await ctx.db
-    .query("manPages")
-    .withIndex("by_releaseId_and_name_and_section", (q) =>
-      q.eq("releaseId", args.releaseId).eq("name", args.name).eq("section", args.section),
-    )
-    .unique();
-}
-
-async function variantsForPage(
-  ctx: QueryCtx,
-  args: {
-    stage: DatasetStage;
-    locale: string;
-    name: string;
-    section: string;
-  },
-): Promise<Array<{ distro: string; datasetReleaseId: string; contentSha256: string }>> {
-  const active = await ctx.db
-    .query("activeReleases")
-    .withIndex("by_stage_and_locale_and_distro", (q) =>
-      q.eq("stage", args.stage).eq("locale", args.locale),
-    )
-    .take(20);
-
-  const variants: Array<{ distro: string; datasetReleaseId: string; contentSha256: string }> = [];
-  for (const item of active) {
-    const page = await pageByNameAndSection(ctx, {
-      releaseId: item.releaseId,
-      name: args.name,
-      section: args.section,
-    });
-    if (!page) continue;
-    variants.push({
-      distro: item.distro,
-      datasetReleaseId: item.datasetReleaseId,
-      contentSha256: page.contentSha256,
-    });
-  }
-
-  variants.sort((a, b) => {
-    const order = (DISTRO_ORDER[a.distro] ?? 99) - (DISTRO_ORDER[b.distro] ?? 99);
-    return order || a.distro.localeCompare(b.distro);
-  });
-  return variants;
 }
 
 export const getInfo = query({
@@ -251,9 +101,10 @@ export const listSection = query({
       .unique();
     if (!stat) return null;
 
+    // Prefer search digests over manPages: same list fields, smaller rows.
     const pages = await ctx.db
-      .query("manPages")
-      .withIndex("by_releaseId_and_section_and_name", (q) =>
+      .query("manPageSearchDocuments")
+      .withIndex("by_releaseId_and_section_and_nameNorm", (q) =>
         q.eq("releaseId", release._id).eq("section", section),
       )
       .take(offset + limit);
@@ -271,79 +122,6 @@ export const listSection = query({
         description: page.description,
       })),
     };
-  },
-});
-
-export const getManByName = query({
-  args: {
-    stage: datasetStageValidator,
-    distro: distroValidator,
-    name: v.string(),
-  },
-  handler: async (ctx, args) => {
-    const name = normalizeName(args.name);
-    const release = await requireActiveRelease(ctx, args);
-    const pages = await ctx.db
-      .query("manPages")
-      .withIndex("by_releaseId_and_name_and_section", (q) =>
-        q.eq("releaseId", release._id).eq("name", name),
-      )
-      .take(20);
-
-    if (!pages.length) return { kind: "not_found" as const };
-    if (pages.length > 1) {
-      return {
-        kind: "ambiguous" as const,
-        options: pages.map((page) => ({
-          section: page.section,
-          title: page.title,
-          description: page.description,
-        })),
-      };
-    }
-
-    const page = pages[0];
-    const content = await pageContent(ctx, page._id);
-    if (!content) return { kind: "not_found" as const };
-    const variants = await variantsForPage(ctx, {
-      stage: args.stage,
-      locale: release.locale,
-      name: page.name,
-      section: page.section,
-    });
-
-    return { kind: "page" as const, data: pageResponse(release, page, content, variants) };
-  },
-});
-
-export const getManByNameAndSection = query({
-  args: {
-    stage: datasetStageValidator,
-    distro: distroValidator,
-    name: v.string(),
-    section: v.string(),
-  },
-  handler: async (ctx, args) => {
-    const name = normalizeName(args.name);
-    const section = normalizeSection(args.section);
-    const release = await requireActiveRelease(ctx, args);
-    const page = await pageByNameAndSection(ctx, {
-      releaseId: release._id,
-      name,
-      section,
-    });
-    if (!page) return null;
-
-    const content = await pageContent(ctx, page._id);
-    if (!content) return null;
-    const variants = await variantsForPage(ctx, {
-      stage: args.stage,
-      locale: release.locale,
-      name: page.name,
-      section: page.section,
-    });
-
-    return pageResponse(release, page, content, variants);
   },
 });
 
@@ -365,30 +143,43 @@ export const getRelated = query({
     });
     if (!page) return null;
 
-    const seeAlso = await ctx.db
-      .query("manPageLinks")
-      .withIndex("by_fromPageId_and_linkType", (q) =>
-        q.eq("fromPageId", page._id).eq("linkType", "see_also"),
-      )
-      .take(50);
-    const xrefs = await ctx.db
-      .query("manPageLinks")
-      .withIndex("by_fromPageId_and_linkType", (q) =>
-        q.eq("fromPageId", page._id).eq("linkType", "xref"),
-      )
-      .take(50);
+    const [seeAlso, xrefs] = await Promise.all([
+      ctx.db
+        .query("manPageLinks")
+        .withIndex("by_fromPageId_and_linkType", (q) =>
+          q.eq("fromPageId", page._id).eq("linkType", "see_also"),
+        )
+        .take(MAX_RELATED_LINKS),
+      ctx.db
+        .query("manPageLinks")
+        .withIndex("by_fromPageId_and_linkType", (q) =>
+          q.eq("fromPageId", page._id).eq("linkType", "xref"),
+        )
+        .take(MAX_RELATED_LINKS),
+    ]);
 
-    const items = [];
+    const uniqueLinks = [];
     const seen = new Set<string>();
     for (const link of [...seeAlso, ...xrefs]) {
       const key = `${link.toName}:${link.toSection}`;
       if (seen.has(key)) continue;
       seen.add(key);
-      const linkedPage = await pageByNameAndSection(ctx, {
-        releaseId: release._id,
-        name: link.toName,
-        section: link.toSection,
-      });
+      uniqueLinks.push(link);
+      if (uniqueLinks.length >= MAX_RELATED_ITEMS) break;
+    }
+
+    const linkedPages = await Promise.all(
+      uniqueLinks.map((link) =>
+        pageByNameAndSection(ctx, {
+          releaseId: release._id,
+          name: link.toName,
+          section: link.toSection,
+        }),
+      ),
+    );
+
+    const items = [];
+    for (const linkedPage of linkedPages) {
       if (!linkedPage) continue;
       items.push({
         name: linkedPage.name,
@@ -396,16 +187,29 @@ export const getRelated = query({
         title: linkedPage.title,
         description: linkedPage.description,
       });
-      if (items.length >= 50) break;
+      if (items.length >= MAX_RELATED_ITEMS) break;
     }
 
     return { items };
   },
 });
 
-type RankedSearchDocument = Doc<"manPageSearchDocuments"> & { rank: number };
+type RankedSearchDocument = {
+  _id: string;
+  name: string;
+  nameNorm: string;
+  section: string;
+  title: string;
+  description: string;
+  snippetText: string;
+  rank: number;
+};
 
-function rankSearchDocument(doc: Doc<"manPageSearchDocuments">, queryNorm: string, index: number): number {
+function rankSearchDocument(
+  doc: { nameNorm: string; descNorm: string },
+  queryNorm: string,
+  index: number,
+): number {
   let rank = 1000 - index;
   if (doc.nameNorm === queryNorm) rank += 10_000;
   if (doc.nameNorm.startsWith(queryNorm)) rank += 2_000;
@@ -440,59 +244,51 @@ export const search = query({
     const release = await requireActiveRelease(ctx, args);
     const takeCount = Math.min(offset + limit + 5, MAX_SEARCH_OFFSET + MAX_SEARCH_LIMIT);
 
-    const prefixDocs: Array<Doc<"manPageSearchDocuments">> = [];
+    // Prefix-only: full-text search currently reads the whole text index per query.
     const prefixQueries = fallbackNorm ? [queryNorm, fallbackNorm] : [queryNorm];
-    for (const prefix of prefixQueries) {
-      const rows = section
-        ? await ctx.db
-            .query("manPageSearchDocuments")
-            .withIndex("by_releaseId_and_section_and_nameNorm", (q) =>
-              q
-                .eq("releaseId", release._id)
-                .eq("section", section)
-                .gte("nameNorm", prefix)
-                .lt("nameNorm", prefixUpperBound(prefix)),
-            )
-            .take(takeCount)
-        : await ctx.db
-            .query("manPageSearchDocuments")
-            .withIndex("by_releaseId_and_nameNorm", (q) =>
-              q
-                .eq("releaseId", release._id)
-                .gte("nameNorm", prefix)
-                .lt("nameNorm", prefixUpperBound(prefix)),
-            )
-            .take(takeCount);
-      prefixDocs.push(...rows);
-    }
-
-    const shouldSearchFullText = shouldUseFullTextSearch({
-      queryNorm,
-      prefixCount: prefixDocs.length,
-      offset,
-      limit,
-    });
-    const searchedDocs = shouldSearchFullText
-      ? section
-        ? await ctx.db
-            .query("manPageSearchDocuments")
-            .withSearchIndex("search_searchText", (q) =>
-              q.search("searchText", queryText).eq("releaseId", release._id).eq("section", section),
-            )
-            .take(takeCount)
-        : await ctx.db
-            .query("manPageSearchDocuments")
-            .withSearchIndex("search_searchText", (q) =>
-              q.search("searchText", queryText).eq("releaseId", release._id),
-            )
-            .take(takeCount)
-      : [];
+    const prefixDocs = (
+      await Promise.all(
+        prefixQueries.map((prefix) =>
+          section
+            ? ctx.db
+                .query("manPageSearchDocuments")
+                .withIndex("by_releaseId_and_section_and_nameNorm", (q) =>
+                  q
+                    .eq("releaseId", release._id)
+                    .eq("section", section)
+                    .gte("nameNorm", prefix)
+                    .lt("nameNorm", prefixUpperBound(prefix)),
+                )
+                .take(takeCount)
+            : ctx.db
+                .query("manPageSearchDocuments")
+                .withIndex("by_releaseId_and_nameNorm", (q) =>
+                  q
+                    .eq("releaseId", release._id)
+                    .gte("nameNorm", prefix)
+                    .lt("nameNorm", prefixUpperBound(prefix)),
+                )
+                .take(takeCount),
+        ),
+      )
+    ).flat();
 
     const ranked = new Map<string, RankedSearchDocument>();
-    [...prefixDocs, ...searchedDocs].forEach((doc, index) => {
+    prefixDocs.forEach((doc, index) => {
       const current = ranked.get(doc._id);
       const rank = rankSearchDocument(doc, queryNorm, index);
-      if (!current || rank > current.rank) ranked.set(doc._id, { ...doc, rank });
+      if (!current || rank > current.rank) {
+        ranked.set(doc._id, {
+          _id: doc._id,
+          name: doc.name,
+          nameNorm: doc.nameNorm,
+          section: doc.section,
+          title: doc.title,
+          description: doc.description,
+          snippetText: doc.snippetText,
+          rank,
+        });
+      }
     });
 
     const ordered = [...ranked.values()].sort((a, b) => {
@@ -521,8 +317,7 @@ export const search = query({
       })),
       suggestions,
       hasMore: ordered.length > offset + limit,
-      nextOffset:
-        ordered.length > offset + limit ? offset + visible.length : null,
+      nextOffset: ordered.length > offset + limit ? offset + visible.length : null,
     };
   },
 });
@@ -611,19 +406,23 @@ export const listSeoReleases = query({
     stage: datasetStageValidator,
   },
   handler: async (ctx, args) => {
-    const items = [];
-    for (const distro of DISTROS) {
-      const release = await activeRelease(ctx, { stage: args.stage, distro });
-      if (!release) continue;
-      items.push({
-        distro,
-        datasetReleaseId: release.datasetReleaseId,
-        ingestedAt: release.ingestedAt,
-        pageCount: release.pageCount,
-      });
-    }
+    const releases = await Promise.all(
+      DISTROS.map(async (distro) => {
+        const release = await activeRelease(ctx, { stage: args.stage, distro });
+        if (!release) return null;
+        return {
+          distro,
+          datasetReleaseId: release.datasetReleaseId,
+          ingestedAt: release.ingestedAt,
+          pageCount: release.pageCount,
+        };
+      }),
+    );
 
-    return { urlsPerFile: SITEMAP_URLS_PER_FILE, items };
+    return {
+      urlsPerFile: SITEMAP_URLS_PER_FILE,
+      items: releases.filter((item): item is NonNullable<typeof item> => item !== null),
+    };
   },
 });
 

--- a/convex/queries.ts
+++ b/convex/queries.ts
@@ -300,6 +300,12 @@ export const search = query({
       return a.section.localeCompare(b.section);
     });
     const visible = ordered.slice(offset, offset + limit);
+    const candidateNextOffset = offset + visible.length;
+    // Never advertise an offset the handler will clamp backward (MAX_SEARCH_OFFSET).
+    const nextOffset =
+      ordered.length > candidateNextOffset && offset < MAX_SEARCH_OFFSET
+        ? Math.min(candidateNextOffset, MAX_SEARCH_OFFSET)
+        : null;
 
     const suggestions = [...new Set(ordered.map((doc) => doc.nameNorm))]
       .filter((name) => name !== queryNorm)
@@ -315,8 +321,8 @@ export const search = query({
         highlights: [deterministicSnippet(doc.snippetText, queryText)].filter(Boolean),
       })),
       suggestions,
-      hasMore: ordered.length > offset + limit,
-      nextOffset: ordered.length > offset + limit ? offset + visible.length : null,
+      hasMore: nextOffset !== null,
+      nextOffset,
     };
   },
 });

--- a/convex/queries.ts
+++ b/convex/queries.ts
@@ -197,6 +197,7 @@ export const getRelated = query({
       if (seen.has(key)) continue;
       seen.add(key);
       uniqueLinks.push(link);
+      if (uniqueLinks.length >= MAX_RELATED) break;
     }
 
     const linkedPages = await Promise.all(
@@ -209,19 +210,16 @@ export const getRelated = query({
       ),
     );
 
-    const items = [];
-    for (const linkedPage of linkedPages) {
-      if (!linkedPage) continue;
-      items.push({
-        name: linkedPage.name,
-        section: linkedPage.section,
-        title: linkedPage.title,
-        description: linkedPage.description,
-      });
-      if (items.length >= MAX_RELATED) break;
-    }
-
-    return { items };
+    return {
+      items: linkedPages
+        .filter((linkedPage): linkedPage is NonNullable<typeof linkedPage> => linkedPage !== null)
+        .map((linkedPage) => ({
+          name: linkedPage.name,
+          section: linkedPage.section,
+          title: linkedPage.title,
+          description: linkedPage.description,
+        })),
+    };
   },
 });
 
@@ -328,12 +326,12 @@ export const suggest = query({
   handler: async (ctx, args) => {
     const name = normalizeName(args.name);
     const release = await requireActiveRelease(ctx, args);
-    const docs = await ctx.db
-      .query("manPageSearchDocuments")
-      .withIndex("by_releaseId_and_nameNorm", (q) =>
-        q.eq("releaseId", release._id).gte("nameNorm", name).lt("nameNorm", prefixUpperBound(name)),
-      )
-      .take(10);
+    const docs = await searchDocsByNamePrefix(ctx, {
+      releaseId: release._id,
+      section: null,
+      prefix: name,
+      takeCount: 10,
+    });
 
     return {
       query: name,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -128,6 +128,8 @@ export default defineSchema({
     .index("by_contentId_and_kind_and_chunkIndex", ["contentId", "kind", "chunkIndex"])
     .index("by_pageId_and_kind_and_chunkIndex", ["pageId", "kind", "chunkIndex"]),
 
+  // Prefix/suggest indexes only — full-text searchIndex retired (too expensive per query).
+  // searchText remains a compact metadata string for ops/compaction, not an FTS corpus.
   manPageSearchDocuments: defineTable({
     pageId: v.id("manPages"),
     releaseId: v.id("datasetReleases"),
@@ -146,11 +148,7 @@ export default defineSchema({
       "releaseId",
       "section",
       "nameNorm",
-    ])
-    .searchIndex("search_searchText", {
-      searchField: "searchText",
-      filterFields: ["releaseId", "section"],
-    }),
+    ]),
 
   manPageLinks: defineTable({
     releaseId: v.id("datasetReleases"),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -77,9 +77,8 @@ export default defineSchema({
   })
     .index("by_contentSha256", ["contentSha256"])
     .index("by_releaseId_and_externalId", ["releaseId", "externalId"])
-    .index("by_releaseId_and_name", ["releaseId", "name"])
+    // by_releaseId_and_name_and_section also covers releaseId+name lookups.
     .index("by_releaseId_and_name_and_section", ["releaseId", "name", "section"])
-    .index("by_releaseId_and_section_and_name", ["releaseId", "section", "name"])
     .index("by_releaseId_and_sitemapPage_and_name", ["releaseId", "sitemapPage", "name"]),
 
   manPageContents: defineTable({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -79,6 +79,7 @@ export default defineSchema({
     .index("by_releaseId_and_externalId", ["releaseId", "externalId"])
     // by_releaseId_and_name_and_section also covers releaseId+name lookups.
     .index("by_releaseId_and_name_and_section", ["releaseId", "name", "section"])
+    .index("by_releaseId_and_section_and_name", ["releaseId", "section", "name"])
     .index("by_releaseId_and_sitemapPage_and_name", ["releaseId", "sitemapPage", "name"]),
 
   manPageContents: defineTable({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Code-audit Convex performance pass plus thermo-nuclear / review follow-ups. Focused on hot public read paths, unused indexes/query exports, and structural cleanup of duplicated legacy content readers.

## Changes
- **Related + distro variants**: parallelize indexed lookups; share helpers via `convex/_releaseLookups.ts`
- **Man page read model**: parallelize `contentPointer` + `variantsForPage` in `pageReadModel`
- **Legacy content readers**: canonicalize in `convex/_legacyContent.ts` (shared by `content.ts` + `maintenance.ts`)
- **Schema**: drop unused `manPages.by_releaseId_and_name`; retire FTS `search_searchText` index
- **Search docs**: `searchText` is metadata-only (prefix/suggest); no FTS corpus body
- **API cleanup**: remove unused `queries.getManByName*` content-loading queries (Next.js uses `content.*` actions)
- **getRelated**: parallel resolve of unique see_also/xref candidates, then fill until `MAX_RELATED` resolved pages
- **suggest**: reuse `searchDocsByNamePrefix`
- Docs: `SPEC.md` + `PLAN.md` updated

## Review feedback addressed
- Greptile P1 listSection table mismatch — superseded (section browse stays on `manPages`)
- Greptile/Bugbot getRelated underfill — fixed (fill until resolved)
- Greptile P2 dead break guard — removed

## Deferred
- Cursor pagination for deep `listSection` offsets
- Denormalize title/description onto `manPageLinks`
- Dedicated slim section-list digest table if production insights show high bytes/doc

## Test plan
- [x] `pnpm convex:check`
- [x] CI green on latest push (prior revision); re-run after getRelated fill fix
- [ ] Spot-check `/section/1`, `/man/tar/1` related panel, and search/suggest
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6e48-f5ac-7fd7-95cf-daeae8682e52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6e48-f5ac-7fd7-95cf-daeae8682e52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved man page reads by parallelizing related-page and release-variant lookups.
  * Reduced work in content retrieval and storage-migration by switching to bulk field loading.
  * Enhanced related-item fetching by deduplicating and capping results consistently.

* **Search**
  * Updated search and suggestions to use faster prefix-based matching only.
  * Retired full-text search behavior/indexing.

* **Documentation**
  * Updated deployment and endpoint behavior notes.
  * Added a post-release performance audit section and listed optional follow-up optimizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->