### PR TITLE
ci: automate verified Vercel production deploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@
 # REDIS_URL=redis://localhost:6379/0
 ENV=dev
 
-# Public base URL for absolute links (optional)
-PUBLIC_BASE_URL=http://localhost:8000
+# Public Next.js base URL for absolute links (set to https://betterman.sh in production)
+PUBLIC_BASE_URL=http://localhost:3000
 
 # Observability (optional, backend)
 SENTRY_DSN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Dependency review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
@@ -42,6 +44,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
@@ -63,6 +67,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
@@ -84,6 +90,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
@@ -100,6 +108,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
@@ -116,6 +126,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
@@ -154,6 +166,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
@@ -187,6 +201,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Dependency review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
@@ -70,11 +70,12 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 26
+          node-version: 24
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm next:grammar
+      - run: pnpm next:test
       - run: pnpm -C nextjs lint
       - run: pnpm -C nextjs build
 
@@ -82,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
@@ -98,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
@@ -114,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
@@ -152,7 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
@@ -185,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
@@ -228,7 +229,7 @@ jobs:
           nohup npx convex dev --tail-logs disable > /tmp/betterman-convex.log 2>&1 &
           echo $! > /tmp/betterman-convex.pid
 
-          for attempt in {1..60}; do
+          for _ in {1..60}; do
             if grep -q "Convex functions ready" /tmp/betterman-convex.log; then
               break
             fi
@@ -267,7 +268,7 @@ jobs:
 
           nohup pnpm -C nextjs exec next start -p 3000 > /tmp/betterman-next.log 2>&1 &
 
-          for attempt in {1..60}; do
+          for _ in {1..60}; do
             if curl -fsS http://127.0.0.1:3000/robots.txt >/dev/null; then
               exit 0
             fi
@@ -282,116 +283,3 @@ jobs:
         env:
           E2E_BASE_URL: http://127.0.0.1:3000
         run: pnpm -C frontend e2e
-
-  deploy_railway:
-    needs:
-      - frontend
-      - nextjs
-      - backend
-      - ingestion
-      - api_types
-      - container_build
-      - e2e
-    if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: 26
-
-      - name: Install Railway CLI
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          export RAILWAY_VERSION="4.18.2"
-          export npm_config_prefix="${RUNNER_TEMP}/railway-npm"
-          railway_bin="${npm_config_prefix}/bin"
-          mkdir -p "$railway_bin"
-          export PATH="${railway_bin}:${PATH}"
-          echo "$railway_bin" >> "$GITHUB_PATH"
-
-          for attempt in 1 2 3; do
-            echo "Installing @railway/cli@${RAILWAY_VERSION} (attempt $attempt/3)…"
-            if npm install -g "@railway/cli@${RAILWAY_VERSION}"; then
-              break
-            fi
-            sleep $((attempt * 10))
-          done
-
-          if ! command -v railway >/dev/null 2>&1; then
-            echo "Failed to install Railway CLI (@railway/cli@${RAILWAY_VERSION}) after 3 attempts." >&2
-            exit 1
-          fi
-
-          railway --version
-
-      - name: Deploy web (Railway)
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          RAILWAY_WORKSPACE_ID: ed8a9f0d-ab1b-48a4-a7a1-86a95b0e5f18
-          RAILWAY_PROJECT_ID: efecaef3-7389-4b3e-b767-5f56858b845e
-          RAILWAY_ENVIRONMENT_ID: dc10158e-d1fd-4039-9089-4c6068357251
-          RAILWAY_SERVICE_ID: d254e49e-352c-4678-8933-eab6422a02c1
-          RAILWAY_NEXTJS_SERVICE_ID: 40fa322d-c334-4662-8858-8edf380d3f10
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [[ -z "${RAILWAY_TOKEN:-}" ]]; then
-            echo "Missing RAILWAY_TOKEN GitHub Actions secret."
-            exit 1
-          fi
-
-          railway_project_token() {
-            env RAILWAY_TOKEN="$RAILWAY_TOKEN" railway "$@"
-          }
-
-          railway_bearer_token() {
-            env -u RAILWAY_TOKEN RAILWAY_API_TOKEN="$RAILWAY_TOKEN" railway "$@"
-          }
-
-          railway_run() {
-            local output
-            local status
-
-            set +e
-            output="$(railway_project_token "$@" 2>&1)"
-            status=$?
-            set -e
-            printf '%s\n' "$output"
-
-            if [[ $status -eq 0 ]]; then
-              return 0
-            fi
-
-            if ! grep -qi "Unauthorized" <<<"$output"; then
-              return "$status"
-            fi
-
-            echo "Project-token auth rejected; retrying with bearer-token compatibility path..."
-            railway_bearer_token "$@"
-          }
-
-          deploy_service() {
-            local service_id="$1"
-
-            if railway_run up --ci \
-              --project "$RAILWAY_PROJECT_ID" \
-              --service "$service_id" \
-              --environment "$RAILWAY_ENVIRONMENT_ID"; then
-              return 0
-            fi
-
-            railway_run logs --deployment --lines 200 --latest \
-              --service "$service_id" \
-              --environment "$RAILWAY_ENVIRONMENT_ID" || true
-            return 1
-          }
-
-          deploy_service "$RAILWAY_SERVICE_ID"
-          deploy_service "$RAILWAY_NEXTJS_SERVICE_ID"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
     name: Analyze (python)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
@@ -40,7 +40,7 @@ jobs:
     name: Analyze (javascript-typescript)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,8 @@ jobs:
   resolve_revision:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,122 +1,134 @@
-name: deploy-railway
+name: deploy-vercel
 
 on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
-      ref:
-        description: "Git ref (branch, tag, SHA) to deploy"
-        required: false
-        default: main
-
-concurrency:
-  group: deploy-railway-${{ inputs.ref }}
-  cancel-in-progress: false
+      sha:
+        description: "Full 40-character SHA from main history to deploy or roll back to"
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
-  deploy_web:
+  resolve_revision:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-      RAILWAY_WORKSPACE_ID: ed8a9f0d-ab1b-48a4-a7a1-86a95b0e5f18
-      RAILWAY_PROJECT_ID: efecaef3-7389-4b3e-b767-5f56858b845e
-      RAILWAY_ENVIRONMENT_ID: dc10158e-d1fd-4039-9089-4c6068357251
-      RAILWAY_SERVICE_ID: d254e49e-352c-4678-8933-eab6422a02c1
-      RAILWAY_NEXTJS_SERVICE_ID: 40fa322d-c334-4662-8858-8edf380d3f10
+    timeout-minutes: 5
+    outputs:
+      ref: ${{ steps.revision.outputs.ref }}
+      sha: ${{ steps.revision.outputs.sha }}
+      require_current_main: ${{ steps.revision.outputs.require_current_main }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve and validate deployment revision
+        id: revision
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_SHA: ${{ inputs.sha }}
+          WORKFLOW_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            sha="$WORKFLOW_SHA"
+            ref="main"
+            require_current_main="true"
+          else
+            sha="$MANUAL_SHA"
+            ref="main-history"
+            require_current_main="false"
+
+            if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Manual deployment requires a full lowercase 40-character commit SHA." >&2
+              exit 1
+            fi
+            if ! git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+              echo "Commit ${sha} is not present in repository history." >&2
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "$sha" origin/main; then
+              echo "Commit ${sha} is not reachable from protected main." >&2
+              exit 1
+            fi
+          fi
+
+          if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Resolved deployment revision is not a full commit SHA." >&2
+            exit 1
+          fi
+
+          {
+            printf 'ref=%s\n' "$ref"
+            printf 'sha=%s\n' "$sha"
+            printf 'require_current_main=%s\n' "$require_current_main"
+          } >> "$GITHUB_OUTPUT"
+
+  deploy_production:
+    needs: resolve_revision
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: deploy-vercel-production
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      deployments: write
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.deployment_url }}
+    env:
+      BETTERMAN_DEPLOY_REF: ${{ needs.resolve_revision.outputs.ref }}
+      BETTERMAN_DEPLOY_SHA: ${{ needs.resolve_revision.outputs.sha }}
+      BETTERMAN_PRODUCTION_DOMAIN: betterman.sh
+      BETTERMAN_REQUIRE_CURRENT_MAIN: ${{ needs.resolve_revision.outputs.require_current_main }}
+    defaults:
+      run:
+        working-directory: app/nextjs
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          path: tooling
+          persist-credentials: false
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.resolve_revision.outputs.sha }}
+          path: app
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 10.34.4
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 26
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: app/pnpm-lock.yaml
 
-      - name: Install Railway CLI
-        shell: bash
-        run: |
-          set -euo pipefail
+      - name: Install Vercel CLI
+        run: npm install --global vercel@58.4.4
 
-          export RAILWAY_VERSION="4.18.2"
-          export npm_config_prefix="${RUNNER_TEMP}/railway-npm"
-          railway_bin="${npm_config_prefix}/bin"
-          mkdir -p "$railway_bin"
-          export PATH="${railway_bin}:${PATH}"
-          echo "$railway_bin" >> "$GITHUB_PATH"
-
-          for attempt in 1 2 3; do
-            echo "Installing @railway/cli@${RAILWAY_VERSION} (attempt $attempt/3)…"
-            if npm install -g "@railway/cli@${RAILWAY_VERSION}"; then
-              break
-            fi
-            sleep $((attempt * 10))
-          done
-
-          if ! command -v railway >/dev/null 2>&1; then
-            echo "Failed to install Railway CLI (@railway/cli@${RAILWAY_VERSION}) after 3 attempts." >&2
-            exit 1
-          fi
-
-          railway --version
-
-      - name: Deploy services
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [[ -z "${RAILWAY_TOKEN:-}" ]]; then
-            echo "Missing RAILWAY_TOKEN GitHub Actions secret."
-            exit 1
-          fi
-
-          railway_project_token() {
-            env RAILWAY_TOKEN="$RAILWAY_TOKEN" railway "$@"
-          }
-
-          railway_bearer_token() {
-            env -u RAILWAY_TOKEN RAILWAY_API_TOKEN="$RAILWAY_TOKEN" railway "$@"
-          }
-
-          railway_run() {
-            local output
-            local status
-
-            set +e
-            output="$(railway_project_token "$@" 2>&1)"
-            status=$?
-            set -e
-            printf '%s\n' "$output"
-
-            if [[ $status -eq 0 ]]; then
-              return 0
-            fi
-
-            if ! grep -qi "Unauthorized" <<<"$output"; then
-              return "$status"
-            fi
-
-            echo "Project-token auth rejected; retrying with bearer-token compatibility path..."
-            railway_bearer_token "$@"
-          }
-
-          deploy_service() {
-            local service_id="$1"
-
-            if railway_run up --ci \
-              --project "$RAILWAY_PROJECT_ID" \
-              --service "$service_id" \
-              --environment "$RAILWAY_ENVIRONMENT_ID"; then
-              return 0
-            fi
-
-            railway_run logs --deployment --lines 200 --latest \
-              --service "$service_id" \
-              --environment "$RAILWAY_ENVIRONMENT_ID" || true
-            return 1
-          }
-
-          deploy_service "$RAILWAY_SERVICE_ID"
-          deploy_service "$RAILWAY_NEXTJS_SERVICE_ID"
+      - name: Deploy and verify production
+        id: deploy
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: ../../tooling/scripts/deploy-vercel.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,4 +131,5 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: ../../tooling/scripts/deploy-vercel.sh
+        run: |
+          "$GITHUB_WORKSPACE/tooling/scripts/deploy-vercel.sh"

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
       security-events: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: true

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -51,7 +51,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || (github.event.inputs.ingest != 'false' && github.event.inputs.linux != 'false') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
@@ -101,7 +101,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || (github.event.inputs.ingest != 'false' && github.event.inputs.bsd != 'false') }}
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
@@ -128,7 +128,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || (github.event.inputs.ingest != 'false' && github.event.inputs.bsd != 'false') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Ingest FreeBSD to Convex staging
         uses: vmactions/freebsd-vm@7ca82f79fe3078fecded6d3a2bff094995447bbd # v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to BetterMan are documented here.
 
 ## Unreleased
 
+- CI/CD: make Vercel the gated production target, deploy the exact tested `main` SHA, stage and verify before promotion, and automatically roll back failed post-promotion checks. ([#140](https://github.com/amanthanvi/BetterMan/pull/140)) — thanks @amanthanvi
 - Performance: metadata-only page reads, split search ranking/headline queries, client-loaded related commands, heuristic document virtualization, near-viewport syntax highlighting, critical-font preloads, and `Server-Timing` diagnostics. ([#139](https://github.com/amanthanvi/BetterMan/pull/139)) — thanks @amanthanvi
 - Security: move transitive `brace-expansion` 1.x/2.x overrides beyond GHSA-mh99-v99m-4gvg vulnerable ranges. ([#139](https://github.com/amanthanvi/BetterMan/pull/139))
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -372,7 +372,7 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 - [x] Ingestion: validate Debian package names and resolve symlinks before reading `/usr/share/doc/<pkg>/copyright`.
 - [x] Next.js: strip `__BM_*__` highlight sentinels from man page text before marker application.
 - [x] Dependencies: `next` to 15.5.22, `seroval` to 1.5.6 (critical GHSA-mv8w-475r-vwqw), pnpm pin to 10.34.4 (CVE-2026-59195), plus patched `brace-expansion` overrides for GHSA-mh99-v99m-4gvg.
-- [ ] Follow-up: `nextjs/lib/public-origin.ts` falls back to `x-forwarded-host`; set `PUBLIC_BASE_URL` in production or validate the host against an allowlist.
+- [x] Public origin: enforce `https://betterman.sh` for production, inject `PUBLIC_BASE_URL` at deploy time, and ignore forwarding headers in production.
 - [ ] Follow-up: `backend/app/web/{seo,runtime_config}.py` are unmounted and superseded by the Next.js routes — decide which implementation is canonical and delete the other.
 - [ ] Follow-up: public Convex queries accept `stage` from the caller, so `staging` data is readable directly from the deployment; derive it server-side.
 
@@ -385,3 +385,11 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 - [x] Improve large man-page rendering with heuristic virtualization + viewport-gated code highlighting.
 - [x] Preload critical fonts to reduce first-paint CLS on man pages.
 - [ ] Tag `v0.6.5`
+
+### Production delivery hardening (v0.6.5 cycle)
+
+- [x] Make Vercel the documented production host and retain Railway only as legacy infrastructure.
+- [x] Replace the best-effort Railway deploy with a non-cancelable Vercel workflow gated on successful `main` CI.
+- [x] Pin the Vercel CLI and deploy a prebuilt artifact from the exact tested checkout SHA.
+- [x] Verify deployment metadata, Convex-backed API data, canonical robots/sitemaps, a representative man page, and both production aliases in automation.
+- [x] Keep a manual protected-`main` SHA workflow for explicit rollback and recovery.

--- a/README.md
+++ b/README.md
@@ -48,16 +48,18 @@ BetterMan is a fast, readable web UI for `man` pages — built to feel like a to
 ## Status
 
 - Latest release: `v0.6.4` (tag `v0.6.4`)
-- In progress: TBD (see `ROADMAP.md` + `PLAN.md`)
+- In progress: `v0.6.5` (see `ROADMAP.md` + `PLAN.md`)
 - Default branch: `main`
 
-## Deploy (Railway)
+## Deploy (Vercel)
 
-- Auto-deploy: `.github/workflows/ci.yml` deploys after all jobs pass on pushes to `main`.
-- Manual deploy: `.github/workflows/deploy.yml` (workflow `deploy-railway`, input `ref`).
-- Requires `RAILWAY_TOKEN` GitHub Actions secret (used as Railway project-token auth in CI).
-- Current runtime: `nextjs` reads datasets/search/rate limits from Convex.
-- Legacy `web` FastAPI service may still exist during the infrastructure transition, but the active Next.js app no longer requires `FASTAPI_INTERNAL_URL`.
+- Production: Vercel project `betterman`, with `betterman.sh` and `www.betterman.sh` assigned to its production deployment.
+- Auto-deploy: `.github/workflows/deploy.yml` starts only after `.github/workflows/ci.yml` succeeds for a push to `main`, then rechecks that exact SHA before promotion.
+- Manual deploy/rollback: `.github/workflows/deploy.yml` (workflow `deploy-vercel`, input `sha`) accepts only a full commit SHA reachable from protected `main` history.
+- Required `production` environment secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`; the environment is restricted to protected branches and repository-scoped Vercel secrets are prohibited.
+- The deployment root is `nextjs/`; `scripts/deploy-vercel.sh` builds the exact checkout SHA, verifies authenticated deployment metadata, smoke-tests a staged artifact, promotes only a passing artifact, verifies both custom-domain aliases, and rolls back if post-promotion verification fails.
+- Current runtime: Next.js on Vercel reads datasets, search, and rate-limit state from Convex. Legacy Railway services are not on the active request path.
+- Operations and rollback: `docs/runbooks/vercel-ops.md`.
 
 ## Dataset updates
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1064,12 +1064,22 @@ flowchart LR
   NX -->|SSR + Static Assets| U
 ```
 
-**Deployment Platform:** Railway for all services (web, PostgreSQL, Redis). v0.5.0 splits the single web service into Next.js (public-facing) and FastAPI (internal API via Railway private networking).
+**Current production topology (v0.6.5 delivery hardening):**
+
+```mermaid
+flowchart LR
+  U[User Browser] -->|HTTPS| VX[Next.js on Vercel]
+  VX -->|Queries, Actions, File Storage| CV[(Convex Production)]
+  VX -->|SSR + Static Assets + /api/*| U
+  FA[Legacy FastAPI on Railway] -. not on active request path .-> VX
+```
+
+**Deployment Platform:** Vercel is the active public Next.js host and Convex owns production data, search, and rate limits. Legacy FastAPI/Railway infrastructure may remain during cleanup but is not required by the active request path. A non-cancelable GitHub Actions workflow stages the exact tested `main` SHA, verifies it before promotion, and confirms both production aliases.
 
 ## Frontend Architecture
 
 **Stack Decisions:**
--   **Runtime:** Node 26
+-   **Runtime:** Node 24 for the active Next.js/Vercel build and runtime; Node 26 remains in legacy frontend/container tooling
 -   **Build Tool:** Vite (**v0.5.0:** Next.js App Router replaces Vite)
 -   **Framework:** React + TypeScript SPA (**v0.5.0:** Next.js with SSR + streaming + client hydration)
 -   **Router:** TanStack Router (type-safe routing with excellent TypeScript integration) (**v0.5.0:** Next.js file-based App Router)
@@ -1814,16 +1824,16 @@ Detailed step-by-step runbooks located in `docs/runbooks/`:
     - Check browser DevTools console for CSP violation reports
     - Identify source of violation (inline styles, scripts, third-party)
     - Verify nonce injection is working correctly
-    - If emergency: set `CSP_ENABLED=false` in Railway env vars
+    - If emergency: set `CSP_ENABLED=false` in the Vercel production environment and redeploy the selected SHA
     - For style violations from TanStack Virtual: expected (documented tradeoff)
 
-7. **Railway operations** (`docs/runbooks/railway-ops.md`)
-    - Deploy: automatic on push to `main` after CI passes
-    - Manual deploy: `gh workflow run deploy.yml -f ref=<branch>`
-    - View logs: Railway dashboard or `railway logs`
-    - Restart service: Railway dashboard "Restart" button
-    - Scale: adjust instance count in Railway settings
-    - Environment variables: Railway dashboard "Variables" tab
+7. **Vercel operations** (`docs/runbooks/vercel-ops.md`)
+    - Deploy: non-cancelable workflow after successful `main` CI
+    - Manual deploy/rollback: `gh workflow run deploy.yml -f sha=<full-main-history-sha>`
+    - View runtime and build logs in Vercel
+    - Promote only after immutable deployment smoke checks pass
+    - Automatically restore the prior deployment when post-promotion verification fails
+    - Keep Railway operations limited to explicitly labeled legacy services
 
 8. **E2E test failures** (`docs/runbooks/e2e-debug.md`)
     - Check CI artifacts for Playwright traces and screenshots
@@ -1897,14 +1907,13 @@ Staging and prod must be isolated:
     -   Backend + ingestion uv lockfiles
     -   Docker base images
 
-### `deploy.yml` (deploy/promote/rollback)
+### `deploy.yml` (Vercel stage/promote/rollback)
 
--   Deploy to staging on merge to main
--   Run smoke tests against staging
--   Manual approval step to promote to prod
--   Rollback:
-    -   redeploy previous artifact
-    -   optionally flip dataset release pointer to previous release
+-   Trigger only after successful CI for a push to `main`, or by explicit manual dispatch with a full SHA from protected `main` history
+-   Build an immutable production-targeted deployment without moving domains
+-   Verify exact-SHA metadata and smoke-test API, robots, sitemaps, and a representative man page
+-   Recheck current `main`, promote, and verify both production aliases
+-   Roll back to the previously captured deployment if post-promotion verification fails
 
 ### `update-docs.yml` (ingest/parse/validate/index/publish)
 
@@ -2532,7 +2541,7 @@ All open questions have been resolved through the interview process:
 -   Linting: **ESLint**
 -   Testing (v0.2.0): **Vitest + Testing Library** (unit), **Playwright** (E2E), **axe-core** (a11y)
 -   Virtualization (v0.2.0): **TanStack Virtual** (100+ blocks threshold)
--   Runtime: **Node 26**
+-   Runtime: **Node 24** for Next.js/Vercel; **Node 26** for retained legacy frontend/container tooling
 
 ### Backend Stack
 -   Framework: **FastAPI**
@@ -2842,7 +2851,7 @@ v0.4.0 is **non-breaking**. All changes are additive or internal improvements.
 
 **Testing**
 
--   [x] CI green on `main` (including `deploy_railway`)
+-   [x] CI was green on `main` for this historical release (including the then-current `deploy_railway` job)
 -   [x] Coverage >= 60% and increased test suite (backend + frontend + ingestion + E2E)
 
 **Release**
@@ -2919,9 +2928,9 @@ frontend/src/routes/licenses.tsx  →  app/licenses/page.tsx
 
 ### Deployment Topology
 
-Two Railway services:
+Current production services:
 
-1. **Next.js Service** (public-facing):
+1. **Next.js Service on Vercel** (public-facing):
    - Handles all web traffic (SSR + static assets)
    - Serves `/api/*` through Next.js route handlers backed by Convex queries/actions
    - Man page bodies load via `content.getManByName*` actions (file storage), not query-transaction JSON
@@ -2931,7 +2940,11 @@ Two Railway services:
    - Public domain: `betterman.sh`
    - Env: `NEXT_PUBLIC_CONVEX_URL` or `CONVEX_URL`, `BETTERMAN_DATASET_STAGE`, `NEXT_PUBLIC_SENTRY_DSN`, `NEXT_PUBLIC_PLAUSIBLE_DOMAIN`
 
-2. **FastAPI Service** (legacy/internal during cutover):
+2. **Convex Production** (active data plane):
+   - Owns dataset reads, search, content actions, file storage, and rate-limit state
+   - Selected with `BETTERMAN_DATASET_STAGE=prod`
+
+3. **FastAPI Service on Railway** (legacy/internal during cleanup):
    - No longer required by active Next.js runtime
    - Retained for maintenance until infrastructure cleanup is explicitly approved
    - Keeps PostgreSQL/Redis connections, rate limiting, Sentry backend

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,6 +35,9 @@ Convex (convex/)
 
 GitHub Actions (ingestion/)
   └─ builds + promotes dataset release pointers through Convex HTTP actions
+
+GitHub Actions (ci → deploy workflow_run)
+  └─ stages, verifies, and promotes the exact tested main SHA to Next.js on Vercel
 ```
 
 ## Key flows
@@ -67,15 +70,15 @@ GitHub Actions (ingestion/)
 
 ## Deployment
 
-Production deploy is handled by GitHub Actions after CI passes on pushes to `main`.
+Production deploy is handled by a non-cancelable GitHub Actions workflow after CI passes on pushes to `main`.
 
 - CI: `.github/workflows/ci.yml`
 - Deploy workflow: `.github/workflows/deploy.yml`
-- Ops notes: `docs/runbooks/railway-ops.md`
+- Ops notes: `docs/runbooks/vercel-ops.md`
 
 ### Runtime topology
 
-- `nextjs` — public web (Next.js)
+- `nextjs` — public web (Next.js on Vercel)
 - Convex — app data, search, ingestion, and rate-limit state
 - `web` — legacy FastAPI API-only service retained until infrastructure cleanup is approved
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -10,6 +10,7 @@ Runbooks referenced by `SPEC.md` Section 17.
 - `docs/runbooks/backups-restore.md`
 - `docs/runbooks/logging-redaction.md`
 - `docs/runbooks/csp-violations.md`
+- `docs/runbooks/vercel-ops.md`
 - `docs/runbooks/railway-ops.md`
 - `docs/runbooks/e2e-debug.md`
 - `docs/runbooks/type-gen.md`

--- a/docs/runbooks/backups-restore.md
+++ b/docs/runbooks/backups-restore.md
@@ -1,5 +1,7 @@
 # Backups & restore drill
 
+> **Legacy PostgreSQL reference.** Current production data is owned by Convex. Use Convex production backup/restore controls and validate the active release pointer before applying this PostgreSQL drill to any retained Railway service.
+
 **Goal**
 
 - Maintain daily automated Postgres backups with ≥14 day retention.

--- a/docs/runbooks/csp-violations.md
+++ b/docs/runbooks/csp-violations.md
@@ -35,6 +35,8 @@ BetterMan uses CSP with **strict script nonces** and **relaxed styles** (see `SP
 
 Disable CSP header injection on the **Next** service:
 
-- Set `CSP_ENABLED=false` in the Vercel production environment and redeploy the selected production SHA.
+- Set `CSP_ENABLED=false` in the Vercel production environment.
+- Redeploy the selected full SHA through the `deploy-vercel` workflow and verify its deployment metadata/aliases using `docs/runbooks/vercel-ops.md`.
+- Confirm in browser Network tools that the emergency deployment omits the `Content-Security-Policy` header and restores the broken flow.
 
-Then redeploy/restart the service.
+After the incident fix is ready, set `CSP_ENABLED=true`, redeploy the selected production SHA, and confirm HTML responses again contain `Content-Security-Policy` with a per-response `nonce-…` in `script-src`. Do not leave the emergency override disabled.

--- a/docs/runbooks/csp-violations.md
+++ b/docs/runbooks/csp-violations.md
@@ -35,6 +35,6 @@ BetterMan uses CSP with **strict script nonces** and **relaxed styles** (see `SP
 
 Disable CSP header injection on the **Next** service:
 
-- Set `CSP_ENABLED=false` in Railway env vars for the Next service.
+- Set `CSP_ENABLED=false` in the Vercel production environment and redeploy the selected production SHA.
 
 Then redeploy/restart the service.

--- a/docs/runbooks/db-connection-exhaustion.md
+++ b/docs/runbooks/db-connection-exhaustion.md
@@ -1,5 +1,7 @@
 # DB connection exhaustion
 
+> **Legacy FastAPI/Railway reference.** The active Vercel + Convex request path does not use the PostgreSQL pool described below. For current incidents, inspect Vercel function errors and Convex dashboard health first.
+
 **Symptoms**
 
 - Rising latency across all endpoints.

--- a/docs/runbooks/man-fetch-500.md
+++ b/docs/runbooks/man-fetch-500.md
@@ -1,6 +1,6 @@
 # Man page fetch returning 500
 
-> **Current topology note.** Production man-page requests run through Next.js on Vercel and Convex content actions/file storage. Use Vercel request logs and Convex function logs for the active dataset stage. Database-health and `is_active` instructions below apply only to the retained legacy FastAPI/Railway path; current rollback changes the Convex release pointer.
+> **Current topology note.** Production man-page requests run through Next.js on Vercel and Convex content actions/file storage. Current dataset rollback follows the `Rollback` section in `docs/runbooks/convex-production-cutover.md`; application rollback follows `docs/runbooks/vercel-ops.md`.
 
 **Symptoms**
 
@@ -9,14 +9,19 @@
 
 **Immediate checks**
 
-- App logs for the request id (`X-Request-ID`) and exception traces.
+- Vercel request logs and Convex function logs for the active dataset stage, correlated by request time and route.
 - Confirm whether failures are isolated (single page) or broad.
-- Check DB health (timeouts / connection errors).
+- Check `/api/v1/info` for the active `datasetReleaseId` and compare failures across distros.
 
 **Mitigations**
 
 - If isolated to a few pages: mark as known-bad in ingestion validation and re-run ingest.
-- If broad / release-correlated: roll back dataset release (set previous release `is_active = true`).
+- If broad and release-correlated: re-promote the previous known-good Convex release pointer using `docs/runbooks/convex-production-cutover.md`; do not delete the failing release during response.
+- If code/deployment-correlated: roll back the application with `docs/runbooks/vercel-ops.md`.
+
+## Legacy FastAPI/Railway path
+
+For a deliberately retained legacy service, also inspect database health and set the previous release `is_active = true` when rolling back its PostgreSQL data. These instructions do not apply to the active Convex data plane.
 
 **Follow-ups**
 

--- a/docs/runbooks/man-fetch-500.md
+++ b/docs/runbooks/man-fetch-500.md
@@ -1,5 +1,7 @@
 # Man page fetch returning 500
 
+> **Current topology note.** Production man-page requests run through Next.js on Vercel and Convex content actions/file storage. Use Vercel request logs and Convex function logs for the active dataset stage. Database-health and `is_active` instructions below apply only to the retained legacy FastAPI/Railway path; current rollback changes the Convex release pointer.
+
 **Symptoms**
 
 - `/api/v1/man/{name}/{section}` returns 500 for specific pages.

--- a/docs/runbooks/railway-ops.md
+++ b/docs/runbooks/railway-ops.md
@@ -1,6 +1,6 @@
-# Railway operations
+# Legacy Railway operations
 
-BetterMan deploys to Railway.
+BetterMan's active public Next.js application deploys to Vercel. Railway services may remain available during infrastructure cleanup, but they are not on the active `betterman.sh` request path. See `docs/runbooks/vercel-ops.md` for current production operations.
 
 ## Current notes
 
@@ -8,24 +8,21 @@ BetterMan deploys to Railway.
 - The active app reads datasets/search/rate-limit state from Convex.
 - `web` (FastAPI) may still exist as a legacy service during the infrastructure transition, but Next no longer proxies `/api/*` to it.
 
-## Deploy
+## Legacy deploy
 
-### Automatic (default)
+There is no automatic Railway deployment from `main`.
 
-- Push to `main`.
-- GitHub Actions runs `.github/workflows/ci.yml`.
-- If all CI jobs pass, the `deploy_railway` job deploys via Railway CLI.
-
-### Manual (workflow dispatch)
-
-- Run the GitHub Actions workflow `.github/workflows/deploy.yml` (`deploy-railway`).
-- Input `ref` can be a branch, tag, or SHA to deploy.
+- Use Railway's dashboard or CLI only when deliberately maintaining or recovering a legacy service.
+- Do not point `betterman.sh` back to Railway without an explicit cutover and rollback plan.
 
 ## Rollback
 
-- Re-run the manual deploy workflow (`deploy-railway`) with a previous known-good `ref` (SHA or tag).
+- Public production rollback is a Vercel operation; follow `docs/runbooks/vercel-ops.md`.
+- Legacy Railway rollback is manual and service-specific.
 
-## Custom domains / cutover
+## Historical custom domains / cutover (do not execute for current production)
+
+The records below describe the former Railway topology. Current production DNS targets Vercel; follow `docs/runbooks/vercel-ops.md`. Retain these notes only for forensic or emergency legacy-service work.
 
 Prereqs:
 

--- a/docs/runbooks/search-latency-spike.md
+++ b/docs/runbooks/search-latency-spike.md
@@ -1,5 +1,7 @@
 # Search latency spike
 
+> **Legacy FastAPI/Railway reference.** Current production search runs through Next.js on Vercel and Convex. For a current incident, correlate Vercel function latency/errors with Convex function logs and query metrics for the active `BETTERMAN_DATASET_STAGE`; the PostgreSQL procedures below apply only to the retained legacy service.
+
 **Symptoms**
 
 - `/api/v1/search` P95 > 500ms (10+ min), timeouts, elevated 5xx.

--- a/docs/runbooks/vercel-ops.md
+++ b/docs/runbooks/vercel-ops.md
@@ -15,7 +15,7 @@ Keep all three secrets only in the protected `production` GitHub environment. Th
 1. Merge to `main`.
 2. `.github/workflows/ci.yml` runs the complete test/build/security matrix.
 3. A non-cancelable `workflow_run` in `.github/workflows/deploy.yml` accepts only a successful `push` CI result for `main`, checks out its exact `head_sha`, installs pinned Vercel CLI `58.4.4`, and runs `scripts/deploy-vercel.sh` from `nextjs/`.
-4. The script pulls production settings, builds a prebuilt artifact, and creates a production-targeted deployment with `--skip-domain`, leaving the current site live.
+4. The script pulls production settings, builds the artifact, and creates a production-targeted deployment with `--skip-domain`, leaving the current site live.
 5. It requires the staged deployment to pass all of the following:
    - deployment state is `READY`;
    - deployment metadata SHA equals the checked-out `main` SHA;

--- a/docs/runbooks/vercel-ops.md
+++ b/docs/runbooks/vercel-ops.md
@@ -1,0 +1,69 @@
+# Vercel production operations
+
+BetterMan's active public Next.js application runs on Vercel. `betterman.sh` and `www.betterman.sh` must resolve to the `betterman` project's current production deployment. Next.js reads production datasets, search, and rate-limit state from Convex.
+
+## Required GitHub Actions secrets
+
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+
+Keep all three secrets only in the protected `production` GitHub environment. That environment permits deployments only from protected branches; repository-scoped Vercel secrets are prohibited. Never commit `.vercel/project.json`, pulled environment files, or token values.
+
+## Automatic deployment
+
+1. Merge to `main`.
+2. `.github/workflows/ci.yml` runs the complete test/build/security matrix.
+3. A non-cancelable `workflow_run` in `.github/workflows/deploy.yml` accepts only a successful `push` CI result for `main`, checks out its exact `head_sha`, installs pinned Vercel CLI `58.4.4`, and runs `scripts/deploy-vercel.sh` from `nextjs/`.
+4. The script pulls production settings, builds a prebuilt artifact, and creates a production-targeted deployment with `--skip-domain`, leaving the current site live.
+5. It requires the staged deployment to pass all of the following:
+   - deployment state is `READY`;
+   - deployment metadata SHA equals the checked-out `main` SHA;
+   - `/api/v1/info` returns an initialized Convex dataset release;
+   - `/robots.txt` is valid;
+   - `/sitemap.xml` is valid;
+   - `/man/tar/1` renders server-side content.
+6. Immediately before promotion, the automatic path confirms the SHA is still current `main`.
+7. Only then does the script promote the deployment and require both `betterman.sh` and `www.betterman.sh` to point to its exact deployment ID and serve initialized API data. A post-promotion failure automatically rolls back to the deployment captured before the run.
+
+The job is not `continue-on-error`. A failed deployment or verification leaves the workflow red.
+
+## Manual deployment or rollback
+
+Run `.github/workflows/deploy.yml` (`deploy-vercel`) from the default `main` workflow definition with a full lowercase 40-character commit SHA. The no-secret validation job requires that commit to be reachable from protected `main`. The deploy job checks out current trusted deployment tooling separately from the selected application revision, then applies the same build, metadata, smoke, promotion, alias, and rollback gates as automatic production deployment.
+
+GitHub concurrency keeps one production deployment running and only the newest request pending. If a manual rollback is replaced by a newer pending request, rerun it after the active deployment finishes. A new successful `main` request intentionally takes precedence over an older pending rollback.
+
+For an urgent platform-level rollback, Vercel also supports:
+
+```bash
+vercel rollback <known-good-deployment-url-or-id>
+```
+
+Prefer the workflow with a known-good Git SHA when possible so the production artifact remains reproducible from repository history.
+
+## Verification
+
+Anonymous command-line requests may receive a Vercel bot challenge (`429` with `x-vercel-mitigated: challenge`). Use authenticated Vercel CLI requests rather than weakening production bot controls:
+
+```bash
+vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+vercel inspect betterman.sh --json --token="$VERCEL_TOKEN"
+vercel curl /api/v1/info
+vercel curl /robots.txt
+vercel curl /man/tar/1
+```
+
+Also verify in a real browser:
+
+- `/` renders without console errors.
+- `/search?q=tar` returns results.
+- `/man/tar/1` renders content and client interactions hydrate.
+
+## Failure triage
+
+- Build failure: inspect the `deploy_vercel` job and Vercel build logs; reproduce with `pnpm next:build`.
+- Missing environment: verify the three GitHub secrets and Vercel production environment variables (`NEXT_PUBLIC_CONVEX_URL` or `CONVEX_URL`, `BETTERMAN_DATASET_STAGE=prod`). The deploy script enforces `PUBLIC_BASE_URL=https://betterman.sh` on each production deployment.
+- Smoke failure: use `vercel curl` against the immutable deployment URL before changing the production alias.
+- Alias mismatch: inspect both the immutable deployment and both custom domains; the script attempts automatic rollback and must not declare success until their deployment IDs match.
+- Runtime errors: inspect Vercel runtime logs/errors and correlate the deployment ID before rolling back.

--- a/docs/runbooks/vercel-ops.md
+++ b/docs/runbooks/vercel-ops.md
@@ -62,7 +62,7 @@ Also verify in a real browser:
 
 ## Failure triage
 
-- Build failure: inspect the `deploy_vercel` job and Vercel build logs; reproduce with `pnpm next:build`.
+- Build failure: inspect the `deploy_production` job in the `deploy-vercel` workflow and Vercel build logs; reproduce with `pnpm next:build`.
 - Missing environment: verify the three GitHub secrets and Vercel production environment variables (`NEXT_PUBLIC_CONVEX_URL` or `CONVEX_URL`, `BETTERMAN_DATASET_STAGE=prod`). The deploy script enforces `PUBLIC_BASE_URL=https://betterman.sh` on each production deployment.
 - Smoke failure: use `vercel curl` against the immutable deployment URL before changing the production alias.
 - Alias mismatch: inspect both the immutable deployment and both custom domains; the script attempts automatic rollback and must not declare success until their deployment IDs match.

--- a/nextjs/lib/public-origin.test.ts
+++ b/nextjs/lib/public-origin.test.ts
@@ -38,7 +38,7 @@ describe('getPublicOrigin', () => {
     expect(getPublicOrigin(request)).toBe('https://betterman.sh')
   })
 
-  it('does not trust forwarding headers for the production canonical origin', () => {
+  it('does not trust forwarding headers when production configuration is missing', () => {
     delete process.env.PUBLIC_BASE_URL
     delete process.env.NEXT_PUBLIC_BASE_URL
     process.env.NODE_ENV = 'production'
@@ -50,7 +50,7 @@ describe('getPublicOrigin', () => {
       },
     })
 
-    expect(getPublicOrigin(request)).toBe('https://betterman.sh')
+    expect(getPublicOrigin(request)).toBe('https://deployment.vercel.app')
   })
 })
 

--- a/nextjs/lib/public-origin.test.ts
+++ b/nextjs/lib/public-origin.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { getPublicOrigin } from './public-origin'
+
+const originalPublicBaseUrl = process.env.PUBLIC_BASE_URL
+const originalNextPublicBaseUrl = process.env.NEXT_PUBLIC_BASE_URL
+const originalRailwayPublicDomain = process.env.RAILWAY_PUBLIC_DOMAIN
+const originalNodeEnv = process.env.NODE_ENV
+
+afterEach(() => {
+  restoreEnv('PUBLIC_BASE_URL', originalPublicBaseUrl)
+  restoreEnv('NEXT_PUBLIC_BASE_URL', originalNextPublicBaseUrl)
+  restoreEnv('RAILWAY_PUBLIC_DOMAIN', originalRailwayPublicDomain)
+  restoreEnv('NODE_ENV', originalNodeEnv)
+})
+
+describe('getPublicOrigin', () => {
+  it('prefers the configured canonical production origin', () => {
+    process.env.PUBLIC_BASE_URL = 'https://betterman.sh/path'
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://www.betterman.sh'
+
+    expect(getPublicOrigin(new Request('https://deployment.vercel.app/robots.txt'))).toBe('https://betterman.sh')
+  })
+
+  it('uses trusted platform forwarding headers when no canonical origin is configured', () => {
+    delete process.env.PUBLIC_BASE_URL
+    delete process.env.NEXT_PUBLIC_BASE_URL
+    process.env.RAILWAY_PUBLIC_DOMAIN = 'stale-legacy.up.railway.app'
+    process.env.NODE_ENV = 'development'
+
+    const request = new Request('http://internal/robots.txt', {
+      headers: {
+        'x-forwarded-host': 'betterman.sh',
+        'x-forwarded-proto': 'https',
+      },
+    })
+
+    expect(getPublicOrigin(request)).toBe('https://betterman.sh')
+  })
+
+  it('does not trust forwarding headers for the production canonical origin', () => {
+    delete process.env.PUBLIC_BASE_URL
+    delete process.env.NEXT_PUBLIC_BASE_URL
+    process.env.NODE_ENV = 'production'
+
+    const request = new Request('https://deployment.vercel.app/robots.txt', {
+      headers: {
+        'x-forwarded-host': 'attacker.example',
+        'x-forwarded-proto': 'https',
+      },
+    })
+
+    expect(getPublicOrigin(request)).toBe('https://betterman.sh')
+  })
+})
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}

--- a/nextjs/lib/public-origin.ts
+++ b/nextjs/lib/public-origin.ts
@@ -10,8 +10,6 @@ function firstHeaderValue(raw: string | null): string | null {
   return first || null
 }
 
-const DEFAULT_PRODUCTION_ORIGIN = 'https://betterman.sh'
-
 export function getPublicOrigin(request: Request): string {
   const env =
     normalizeBaseUrl(process.env.PUBLIC_BASE_URL) ??
@@ -24,7 +22,7 @@ export function getPublicOrigin(request: Request): string {
     }
   }
 
-  if (process.env.NODE_ENV === 'production') return DEFAULT_PRODUCTION_ORIGIN
+  if (process.env.NODE_ENV === 'production') return new URL(request.url).origin
 
   const host =
     firstHeaderValue(request.headers.get('x-forwarded-host')) ??

--- a/nextjs/lib/public-origin.ts
+++ b/nextjs/lib/public-origin.ts
@@ -10,6 +10,8 @@ function firstHeaderValue(raw: string | null): string | null {
   return first || null
 }
 
+const DEFAULT_PRODUCTION_ORIGIN = 'https://betterman.sh'
+
 export function getPublicOrigin(request: Request): string {
   const env =
     normalizeBaseUrl(process.env.PUBLIC_BASE_URL) ??
@@ -22,8 +24,7 @@ export function getPublicOrigin(request: Request): string {
     }
   }
 
-  const railwayPublicDomain = normalizeBaseUrl(process.env.RAILWAY_PUBLIC_DOMAIN)
-  if (railwayPublicDomain) return `https://${railwayPublicDomain}`
+  if (process.env.NODE_ENV === 'production') return DEFAULT_PRODUCTION_ORIGIN
 
   const host =
     firstHeaderValue(request.headers.get('x-forwarded-host')) ??

--- a/scripts/deploy-vercel.sh
+++ b/scripts/deploy-vercel.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_env=(
+  BETTERMAN_DEPLOY_REF
+  BETTERMAN_DEPLOY_SHA
+  BETTERMAN_PRODUCTION_DOMAIN
+  VERCEL_ORG_ID
+  VERCEL_PROJECT_ID
+  VERCEL_TOKEN
+)
+
+for name in "${required_env[@]}"; do
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required environment variable: ${name}" >&2
+    exit 1
+  fi
+done
+
+for command in curl git jq vercel; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "Required command is unavailable: ${command}" >&2
+    exit 1
+  fi
+done
+
+checkout_sha="$(git rev-parse HEAD)"
+if [[ "$checkout_sha" != "$BETTERMAN_DEPLOY_SHA" ]]; then
+  echo "Refusing to deploy: checkout ${checkout_sha} does not match requested SHA ${BETTERMAN_DEPLOY_SHA}." >&2
+  exit 1
+fi
+
+vercel pull \
+  --yes \
+  --environment=production \
+  --token="$VERCEL_TOKEN"
+
+previous_production_json="$(
+  vercel inspect "$BETTERMAN_PRODUCTION_DOMAIN" \
+    --json \
+    --token="$VERCEL_TOKEN"
+)"
+previous_production_id="$(jq -r '.id // .deployment.id // empty' <<<"$previous_production_json")"
+if [[ -z "$previous_production_id" ]]; then
+  echo "Unable to resolve the current production deployment for ${BETTERMAN_PRODUCTION_DOMAIN}." >&2
+  exit 1
+fi
+
+VERCEL_GIT_COMMIT_REF="$BETTERMAN_DEPLOY_REF" \
+  VERCEL_GIT_COMMIT_SHA="$BETTERMAN_DEPLOY_SHA" \
+  vercel build --prod --yes --token="$VERCEL_TOKEN"
+
+deployment_json="$(
+  vercel deploy \
+    --prebuilt \
+    --prod \
+    --skip-domain \
+    --archive=tgz \
+    --yes \
+    --json \
+    --env "PUBLIC_BASE_URL=https://${BETTERMAN_PRODUCTION_DOMAIN}" \
+    --meta "githubCommitSha=${BETTERMAN_DEPLOY_SHA}" \
+    --meta "githubCommitRef=${BETTERMAN_DEPLOY_REF}" \
+    --token="$VERCEL_TOKEN"
+)"
+
+deployment_id="$(jq -r '.id // .deployment.id // empty' <<<"$deployment_json")"
+deployment_url="$(jq -r '.url // .deployment.url // empty' <<<"$deployment_json")"
+
+if [[ -z "$deployment_id" || -z "$deployment_url" ]]; then
+  echo "Vercel returned no deployment ID or URL." >&2
+  jq . <<<"$deployment_json" >&2
+  exit 1
+fi
+
+if [[ "$deployment_url" != https://* ]]; then
+  deployment_url="https://${deployment_url}"
+fi
+
+inspection_json="$(vercel inspect "$deployment_id" --wait --timeout=5m --json --token="$VERCEL_TOKEN")"
+ready_state="$(jq -r '.readyState // .state // .deployment.readyState // .deployment.state // empty' <<<"$inspection_json")"
+deployment_record="$(
+  vercel api "/v13/deployments/${deployment_id}" \
+    --raw \
+    --token="$VERCEL_TOKEN"
+)"
+deployed_sha="$(jq -r '.meta.githubCommitSha // empty' <<<"$deployment_record")"
+
+if [[ "$ready_state" != "READY" ]]; then
+  echo "Deployment ${deployment_id} did not become READY (state=${ready_state:-unknown})." >&2
+  exit 1
+fi
+
+if [[ "$deployed_sha" != "$BETTERMAN_DEPLOY_SHA" ]]; then
+  echo "Deployment metadata SHA ${deployed_sha:-missing} does not match ${BETTERMAN_DEPLOY_SHA}." >&2
+  exit 1
+fi
+
+smoke_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/betterman-vercel-smoke.XXXXXX")"
+
+vercel curl /api/v1/info \
+  --deployment "$deployment_url" \
+  --yes \
+  -- --fail --silent --show-error >"${smoke_dir}/info.json"
+jq -e '.datasetReleaseId | select(type == "string" and length > 0 and . != "uninitialized")' \
+  "${smoke_dir}/info.json" >/dev/null
+
+vercel curl /robots.txt \
+  --deployment "$deployment_url" \
+  --yes \
+  -- --fail --silent --show-error >"${smoke_dir}/robots.txt"
+grep -qi '^User-agent:' "${smoke_dir}/robots.txt"
+grep -Fqi "Sitemap: https://${BETTERMAN_PRODUCTION_DOMAIN}/sitemap.xml" "${smoke_dir}/robots.txt"
+
+vercel curl /sitemap.xml \
+  --deployment "$deployment_url" \
+  --yes \
+  -- --fail --silent --show-error >"${smoke_dir}/sitemap.xml"
+grep -qi '<sitemapindex' "${smoke_dir}/sitemap.xml"
+grep -Fqi "<loc>https://${BETTERMAN_PRODUCTION_DOMAIN}/" "${smoke_dir}/sitemap.xml"
+
+vercel curl /man/tar/1 \
+  --deployment "$deployment_url" \
+  --yes \
+  -- --fail --silent --show-error >"${smoke_dir}/man.html"
+grep -qi '<title>.*tar' "${smoke_dir}/man.html"
+grep -Fqi 'id="bm-jsonld:' "${smoke_dir}/man.html"
+if grep -Fqi 'Not found — BetterMan' "${smoke_dir}/man.html"; then
+  echo "Representative man-page smoke returned the not-found view." >&2
+  exit 1
+fi
+
+if [[ "${BETTERMAN_REQUIRE_CURRENT_MAIN:-false}" == "true" ]]; then
+  current_main_sha="$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')"
+  if [[ "$current_main_sha" != "$BETTERMAN_DEPLOY_SHA" ]]; then
+    echo "Refusing to promote stale SHA ${BETTERMAN_DEPLOY_SHA}; current main is ${current_main_sha:-unknown}." >&2
+    exit 1
+  fi
+fi
+
+promotion_verified=false
+rollback_on_failure() {
+  status="${1:-$?}"
+  trap - EXIT INT TERM
+  if [[ "$status" -ne 0 && "$promotion_verified" != "true" && "$previous_production_id" != "$deployment_id" ]]; then
+    echo "Production verification failed after promotion; rolling back to ${previous_production_id}." >&2
+    vercel rollback "$previous_production_id" --yes --token="$VERCEL_TOKEN" >&2 || \
+      echo "Automatic rollback failed; restore ${previous_production_id} manually." >&2
+  fi
+  exit "$status"
+}
+
+trap rollback_on_failure EXIT
+trap 'rollback_on_failure 130' INT
+trap 'rollback_on_failure 143' TERM
+vercel promote "$deployment_id" \
+  --yes \
+  --timeout=5m \
+  --token="$VERCEL_TOKEN"
+
+for domain in "$BETTERMAN_PRODUCTION_DOMAIN" "www.${BETTERMAN_PRODUCTION_DOMAIN}"; do
+  production_id=""
+  for _ in {1..12}; do
+    production_json="$(vercel inspect "$domain" --json --token="$VERCEL_TOKEN" 2>/dev/null || true)"
+    [[ -n "$production_json" ]] || production_json='{}'
+    production_id="$(jq -r '.id // .deployment.id // empty' <<<"$production_json")"
+    if [[ "$production_id" == "$deployment_id" ]]; then
+      break
+    fi
+    sleep 5
+  done
+
+  if [[ "$production_id" != "$deployment_id" ]]; then
+    echo "Production alias ${domain} points to ${production_id:-unknown}, expected ${deployment_id}." >&2
+    exit 1
+  fi
+
+  vercel curl /api/v1/info \
+    --deployment "https://${domain}" \
+    --yes \
+    -- --fail --location --silent --show-error >"${smoke_dir}/${domain}-info.json"
+  jq -e '.datasetReleaseId | select(type == "string" and length > 0 and . != "uninitialized")' \
+    "${smoke_dir}/${domain}-info.json" >/dev/null
+done
+
+promotion_verified=true
+trap - EXIT INT TERM
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    printf 'deployment_id=%s\n' "$deployment_id"
+    printf 'deployment_url=%s\n' "$deployment_url"
+    printf 'sha=%s\n' "$deployed_sha"
+  } >>"$GITHUB_OUTPUT"
+fi
+
+printf 'Vercel production READY: %s (%s)\n' "$deployment_url" "$deployed_sha"

--- a/scripts/deploy-vercel.sh
+++ b/scripts/deploy-vercel.sh
@@ -145,7 +145,7 @@ rollback_on_failure() {
   status="${1:-$?}"
   trap - EXIT INT TERM
   if [[ "$status" -ne 0 && "$promotion_verified" != "true" && "$previous_production_id" != "$deployment_id" ]]; then
-    echo "Production verification failed after promotion; rolling back to ${previous_production_id}." >&2
+    echo "Production promotion or verification failed; rolling back to ${previous_production_id}." >&2
     vercel rollback "$previous_production_id" --yes --token="$VERCEL_TOKEN" >&2 || \
       echo "Automatic rollback failed; restore ${previous_production_id} manually." >&2
   fi

--- a/scripts/deploy-vercel.sh
+++ b/scripts/deploy-vercel.sh
@@ -47,7 +47,8 @@ if [[ -z "$previous_production_id" ]]; then
   exit 1
 fi
 
-VERCEL_GIT_COMMIT_REF="$BETTERMAN_DEPLOY_REF" \
+PUBLIC_BASE_URL="https://${BETTERMAN_PRODUCTION_DOMAIN}" \
+  VERCEL_GIT_COMMIT_REF="$BETTERMAN_DEPLOY_REF" \
   VERCEL_GIT_COMMIT_SHA="$BETTERMAN_DEPLOY_SHA" \
   vercel build --prod --yes --token="$VERCEL_TOKEN"
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs",
-  "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm -C nextjs build",
-  "outputDirectory": "nextjs/.next"
-}


### PR DESCRIPTION
## Summary
- replace the obsolete best-effort Railway deploy with a non-cancelable Vercel workflow triggered by successful `main` CI
- stage and smoke-test the exact SHA before promotion, verify metadata and both aliases, and roll back failed post-promotion checks
- scope Vercel credentials to a protected GitHub `production` environment and make `nextjs/vercel.json` the sole project config
- enforce the canonical production origin and update current/legacy operations documentation

## Validation
- `bash -n scripts/deploy-vercel.sh`
- `shellcheck scripts/deploy-vercel.sh`
- `actionlint .github/workflows/ci.yml .github/workflows/deploy.yml`
- `pnpm next:lint`
- `pnpm next:test` (25 tests)
- `pnpm next:build`
- `pnpm next:grammar`
- authenticated `vercel curl` smoke against immutable deployment, apex, and `www`
- GitHub `production` environment/secret/branch-policy verification

## Rollout
After squash merge, the new workflow must deploy the merge SHA and prove both production aliases serve that exact READY deployment before this work is considered complete.

## Summary by Sourcery

Replace legacy Railway deploys with a gated, non-cancelable Vercel production delivery workflow that stages the exact tested main SHA, verifies it before promotion, and automatically rolls back on failed post-promotion checks.

New Features:
- Introduce a Vercel-based production deploy workflow that runs after successful main CI or via manual SHA-based dispatch.
- Add a protected manual deploy/rollback path that accepts only full commit SHAs reachable from protected main history.
- Provide a Vercel deployment script that builds from the exact checkout SHA, smoke-tests an immutable deployment, promotes on success, and verifies both production aliases.

Enhancements:
- Align Next.js CI jobs on Node 24 and pin pnpm and Vercel CLI versions for deterministic builds.
- Enforce the canonical production origin by preferring a configured PUBLIC_BASE_URL and treating the live deployment origin as the fallback in production.
- Update architecture and specification docs to describe the Vercel + Convex production topology and new delivery hardening approach.

CI:
- Wire the deploy workflow to the ci workflow via workflow_run events and remove the obsolete best-effort deploy_railway job.
- Upgrade GitHub Actions checkout usage to v6 across CI, CodeQL, docs ingestion, and scorecards workflows.
- Extend the Next.js CI job to run the Vitest test suite alongside linting, grammar, and build steps.

Deployment:
- Add a non-cancelable production deployment job scoped to the protected production environment, using Vercel org/project/token secrets.
- Capture the current production deployment before each run and automatically roll back to it if promotion or alias verification fails.
- Require production deployments to pass metadata, API, robots, sitemap, man-page, and alias checks before being considered successful.

Documentation:
- Document Vercel as the canonical production host and Convex as the active data plane across SPEC, ARCHITECTURE, README, PLAN, and CHANGELOG.
- Add a dedicated Vercel operations runbook covering automatic deploys, manual rollback, verification, and failure triage.
- Reframe Railway and PostgreSQL-related runbooks as legacy references and clarify how they relate to the current Vercel + Convex topology.

Tests:
- Add unit tests for getPublicOrigin to cover canonical origin configuration, trusted forwarding headers in non-production, and secure behavior in production.

Chores:
- Update release planning to track production delivery hardening work for the v0.6.5 cycle and mark v0.6.5 as in progress in project status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Production deployments now use Vercel with staged verification, promotion, and automatic rollback.
  - Added operational guidance for Vercel deployments, rollbacks, smoke tests, and incident handling.
  - Production origin handling now defaults to `https://betterman.sh`.

- **Improvements**
  - CI now uses updated tooling and runs additional Next.js checks.
  - Production deployments are gated by successful CI and tested commit revisions.

- **Documentation**
  - Updated architecture, deployment, security, backup, and legacy Railway guidance to reflect the current production setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->