### PR TITLE
fix(ci): run Vercel CLI from monorepo root

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,7 +99,7 @@ jobs:
       BETTERMAN_REQUIRE_CURRENT_MAIN: ${{ needs.resolve_revision.outputs.require_current_main }}
     defaults:
       run:
-        working-directory: app/nextjs
+        working-directory: app
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ BetterMan is a fast, readable web UI for `man` pages — built to feel like a to
 - Auto-deploy: `.github/workflows/deploy.yml` starts only after `.github/workflows/ci.yml` succeeds for a push to `main`, then rechecks that exact SHA before promotion.
 - Manual deploy/rollback: `.github/workflows/deploy.yml` (workflow `deploy-vercel`, input `sha`) accepts only a full commit SHA reachable from protected `main` history.
 - Required `production` environment secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`; the environment is restricted to protected branches and repository-scoped Vercel secrets are prohibited.
-- The deployment root is `nextjs/`; `scripts/deploy-vercel.sh` builds the exact checkout SHA, verifies authenticated deployment metadata, smoke-tests a staged artifact, promotes only a passing artifact, verifies both custom-domain aliases, and rolls back if post-promotion verification fails.
+- Vercel's project root is `nextjs/`, while CI runs `scripts/deploy-vercel.sh` from the repository root so that setting is applied exactly once. The script builds the exact checkout SHA, verifies authenticated deployment metadata, smoke-tests a staged artifact, promotes only a passing artifact, verifies both custom-domain aliases, and rolls back if post-promotion verification fails.
 - Current runtime: Next.js on Vercel reads datasets, search, and rate-limit state from Convex. Legacy Railway services are not on the active request path.
 - Operations and rollback: `docs/runbooks/vercel-ops.md`.
 

--- a/docs/runbooks/vercel-ops.md
+++ b/docs/runbooks/vercel-ops.md
@@ -14,7 +14,7 @@ Keep all three secrets only in the protected `production` GitHub environment. Th
 
 1. Merge to `main`.
 2. `.github/workflows/ci.yml` runs the complete test/build/security matrix.
-3. A non-cancelable `workflow_run` in `.github/workflows/deploy.yml` accepts only a successful `push` CI result for `main`, checks out its exact `head_sha`, installs pinned Vercel CLI `58.4.4`, and runs `scripts/deploy-vercel.sh` from `nextjs/`.
+3. A non-cancelable `workflow_run` in `.github/workflows/deploy.yml` accepts only a successful `push` CI result for `main`, checks out its exact `head_sha`, installs pinned Vercel CLI `58.4.4`, and runs `scripts/deploy-vercel.sh` from the repository root. Vercel then applies the project's `nextjs` root directory exactly once.
 4. The script pulls production settings, builds the artifact, and creates a production-targeted deployment with `--skip-domain`, leaving the current site live.
 5. It requires the staged deployment to pass all of the following:
    - deployment state is `READY`;

--- a/scripts/deploy-vercel.sh
+++ b/scripts/deploy-vercel.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+if [[ ! -f "nextjs/vercel.json" ]]; then
+  echo "Run this script from the repository root so Vercel can apply rootDirectory=nextjs exactly once." >&2
+  exit 1
+fi
+
 required_env=(
   BETTERMAN_DEPLOY_REF
   BETTERMAN_DEPLOY_SHA


### PR DESCRIPTION
## Summary
- run the Vercel CLI from the monorepo root so project `rootDirectory=nextjs` is applied once
- fail fast when the deploy script is invoked from a nested directory
- document the repository-root invocation contract

## Root cause
Production run 30782174327 built successfully but `vercel deploy --prebuilt` resolved `app/nextjs/nextjs` because the linked project root and workflow cwd both selected `nextjs`. No promotion occurred.

## Validation
- `bash -n scripts/deploy-vercel.sh`
- `shellcheck scripts/deploy-vercel.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/*.yml`
- `git diff --check`
- nested-directory guard returns the intended error before Vercel access
- Opus 5 high independent review: CLEAN