### PR TITLE
fix: document OSV sandbox false positive

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -405,3 +405,4 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 - [x] Remove duplicate regex character-class entries reported by CodeQL.
 - [x] Add property-based API checks and strictly reject malformed decimal pagination values.
 - [x] Remove vulnerable transitive versions from the pinned Vercel CLI dependency graph.
+- [x] Document the bounded OSV exception for Vercel's unrelated `sandbox@3.4.0` package-name collision.

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,9 +1,9 @@
 [[IgnoredVulns]]
 id = "GHSA-fm4j-4xhm-xpwx"
 ignoreUntil = 2027-08-03
-reason = "OSV has no fixed event for the legacy sandbox package, but GitHub bounds the affected range below 1.0.0; this lockfile contains Vercel's unrelated sandbox@3.4.0 package."
+reason = "OSV has no fixed event for the legacy sandbox package, but GitHub bounds the affected range below 1.0.0; this lockfile contains Vercel's unrelated sandbox@3.4.0 package. See https://github.com/advisories/GHSA-fm4j-4xhm-xpwx."
 
 [[IgnoredVulns]]
 id = "GHSA-gc25-3vc5-2jf9"
 ignoreUntil = 2027-08-03
-reason = "OSV has no fixed event for the legacy sandbox package, but GitHub bounds the affected range below 1.0.0; this lockfile contains Vercel's unrelated sandbox@3.4.0 package."
+reason = "OSV has no fixed event for the legacy sandbox package, but GitHub bounds the affected range below 1.0.0; this lockfile contains Vercel's unrelated sandbox@3.4.0 package. See https://github.com/advisories/GHSA-gc25-3vc5-2jf9."

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,9 @@
+[[IgnoredVulns]]
+id = "GHSA-fm4j-4xhm-xpwx"
+ignoreUntil = 2027-08-03
+reason = "OSV has no fixed event for the legacy sandbox package, but GitHub bounds the affected range below 1.0.0; this lockfile contains Vercel's unrelated sandbox@3.4.0 package."
+
+[[IgnoredVulns]]
+id = "GHSA-gc25-3vc5-2jf9"
+ignoreUntil = 2027-08-03
+reason = "OSV has no fixed event for the legacy sandbox package, but GitHub bounds the affected range below 1.0.0; this lockfile contains Vercel's unrelated sandbox@3.4.0 package."


### PR DESCRIPTION
## Summary
- add bounded OSV ignores for two legacy `sandbox <1.0.0` advisories misapplied to Vercel `sandbox@3.4.0`
- expire the exception on 2027-08-03 for forced re-evaluation
- record the completed supply-chain control in PLAN.md

## Validation
- OSV-Scanner v2.4.0 parsed the config, scanned 1,079 packages, suppressed exactly the two listed advisories, and exited 0
- the identical lockfile without the config reproduced exactly those two findings and exited 1
- an unrelated vulnerable lodash negative control still reported five advisories and exited 1
- `pnpm audit --audit-level low` reports zero vulnerabilities
- GitHub reviewed advisories bound the affected legacy package below 1.0.0; the lockfile contains Vercel `sandbox@3.4.0` from `vercel/sandbox`

## Summary by Sourcery

Add a bounded OSV-Scanner ignore configuration for misapplied sandbox advisories and document the exception in the project plan.

CI:
- Introduce an osv-scanner.toml configuration that temporarily ignores two legacy sandbox advisories misapplied to the current dependency graph, with an expiry date for re-evaluation.

Documentation:
- Record the bounded OSV exception for Vercel's unrelated sandbox@3.4.0 package-name collision in PLAN.md.