### PR TITLE
fix: close CI, accessibility, and security risks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,20 +220,27 @@ jobs:
         run: |
           set -euo pipefail
 
-          # --with-deps starts root apt children, so keep an exact process
-          # group for privileged cleanup. Both worst cases consume 765s,
-          # leaving 435s of the job budget for setup, build, and tests.
+          # Run privileged apt/dpkg setup once. Browser-download retries then
+          # cannot inherit or worsen package-manager state from a timed-out
+          # --with-deps attempt.
+          # Worst-case setup plus two retries consumes 780s, preserving 420s
+          # of the 20-minute job budget for checkout, build, and tests.
+          timeout --kill-after=15s 240s \
+            pnpm -C frontend exec playwright install-deps chromium
+
+          # Keep each unprivileged browser download in an exact process group
+          # so a timeout cannot leave pnpm or download children behind.
           install_browser() {
-            setsid --wait timeout --kill-after=15s 360s \
-              pnpm -C frontend exec playwright install --with-deps chromium &
+            setsid --wait timeout --kill-after=15s 240s \
+              pnpm -C frontend exec playwright install chromium &
             local install_group=$!
             local status=0
 
             wait "${install_group}" || status=$?
             if ((status != 0)); then
-              sudo kill -TERM -- "-${install_group}" 2>/dev/null || true
+              kill -TERM -- "-${install_group}" 2>/dev/null || true
               sleep 5
-              sudo kill -KILL -- "-${install_group}" 2>/dev/null || true
+              kill -KILL -- "-${install_group}" 2>/dev/null || true
             fi
 
             return "${status}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,17 +220,20 @@ jobs:
         run: |
           set -euo pipefail
 
+          # --with-deps starts root apt children, so keep an exact process
+          # group for privileged cleanup. Both worst cases consume 765s,
+          # leaving 435s of the job budget for setup, build, and tests.
           install_browser() {
-            setsid --wait timeout --kill-after=30s 600s \
+            setsid --wait timeout --kill-after=15s 360s \
               pnpm -C frontend exec playwright install --with-deps chromium &
             local install_group=$!
             local status=0
 
             wait "${install_group}" || status=$?
             if ((status != 0)); then
-              kill -TERM -- "-${install_group}" 2>/dev/null || true
+              sudo kill -TERM -- "-${install_group}" 2>/dev/null || true
               sleep 5
-              kill -KILL -- "-${install_group}" 2>/dev/null || true
+              sudo kill -KILL -- "-${install_group}" 2>/dev/null || true
             fi
 
             return "${status}"
@@ -241,7 +244,7 @@ jobs:
               exit 0
             fi
             echo "Playwright browser install failed or timed out (attempt ${attempt}/2)." >&2
-            sleep $((attempt * 5))
+            if ((attempt < 2)); then sleep $((attempt * 5)); fi
           done
 
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Dependency review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           # GHSA-mh99-v99m-4gvg (brace-expansion) declares its vulnerable range

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,34 +220,34 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Run privileged apt/dpkg setup once. Browser-download retries then
-          # cannot inherit or worsen package-manager state from a timed-out
-          # --with-deps attempt.
-          # Worst-case setup plus two retries consumes 780s, preserving 420s
-          # of the 20-minute job budget for checkout, build, and tests.
-          timeout --kill-after=15s 240s \
-            pnpm -C frontend exec playwright install-deps chromium
-
-          # Keep each unprivileged browser download in an exact process group
-          # so a timeout cannot leave pnpm or download children behind.
-          install_browser() {
-            setsid --wait timeout --kill-after=15s 240s \
-              pnpm -C frontend exec playwright install chromium &
-            local install_group=$!
-            local status=0
-
-            wait "${install_group}" || status=$?
-            if ((status != 0)); then
-              kill -TERM -- "-${install_group}" 2>/dev/null || true
-              sleep 5
-              kill -KILL -- "-${install_group}" 2>/dev/null || true
+          # A non-timeout apt/mirror failure gets one retry. A timeout stops
+          # immediately so a possibly interrupted dpkg run cannot poison a
+          # second attempt on the same runner.
+          dependencies_ready=false
+          for attempt in 1 2; do
+            status=0
+            timeout --kill-after=15s 180s \
+              pnpm -C frontend exec playwright install-deps chromium || status=$?
+            if ((status == 0)); then
+              dependencies_ready=true
+              break
             fi
+            echo "Playwright dependency install failed (attempt ${attempt}/2, status ${status})." >&2
+            if ((status == 124 || status == 137)); then
+              echo "Dependency setup timed out; refusing an unsafe dpkg retry." >&2
+              exit "${status}"
+            fi
+            if ((attempt < 2)); then sleep 5; fi
+          done
+          if [[ "${dependencies_ready}" != true ]]; then exit 1; fi
 
-            return "${status}"
-          }
+          # GNU timeout owns the unprivileged download process group and kills
+          # remaining children before returning. Two worst-case setup loops use
+          # at most 760s, preserving 440s of the 20-minute job budget.
 
           for attempt in 1 2; do
-            if install_browser; then
+            if timeout --kill-after=15s 180s \
+              pnpm -C frontend exec playwright install chromium; then
               exit 0
             fi
             echo "Playwright browser install failed or timed out (attempt ${attempt}/2)." >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,8 +220,24 @@ jobs:
         run: |
           set -euo pipefail
 
+          install_browser() {
+            setsid --wait timeout --kill-after=30s 600s \
+              pnpm -C frontend exec playwright install --with-deps chromium &
+            local install_group=$!
+            local status=0
+
+            wait "${install_group}" || status=$?
+            if ((status != 0)); then
+              kill -TERM -- "-${install_group}" 2>/dev/null || true
+              sleep 5
+              kill -KILL -- "-${install_group}" 2>/dev/null || true
+            fi
+
+            return "${status}"
+          }
+
           for attempt in 1 2; do
-            if timeout 300s pnpm -C frontend exec playwright install --with-deps chromium; then
+            if install_browser; then
               exit 0
             fi
             echo "Playwright browser install failed or timed out (attempt ${attempt}/2)." >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to BetterMan are documented here.
 
 ## Unreleased
 
+- Reliability/accessibility: eliminate transient entrance-animation contrast failures, make man-page find focus deterministic, and move dependency review to Node 24.
 - CI/CD: make Vercel the gated production target, deploy the exact tested `main` SHA, stage and verify before promotion, and automatically roll back failed post-promotion checks. ([#140](https://github.com/amanthanvi/BetterMan/pull/140)) — thanks @amanthanvi
 - Performance: metadata-only page reads, split search ranking/headline queries, client-loaded related commands, heuristic document virtualization, near-viewport syntax highlighting, critical-font preloads, and `Server-Timing` diagnostics. ([#139](https://github.com/amanthanvi/BetterMan/pull/139)) — thanks @amanthanvi
 - Security: move transitive `brace-expansion` 1.x/2.x overrides beyond GHSA-mh99-v99m-4gvg vulnerable ranges. ([#139](https://github.com/amanthanvi/BetterMan/pull/139))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to BetterMan are documented here.
 
 ## Unreleased
 
+- Security: upgrade Click to 8.4.2 to resolve PYSEC-2026-2132 command injection exposure in `click.edit()`.
 - Reliability/accessibility: eliminate transient entrance-animation contrast failures, make man-page find focus deterministic, and move dependency review to Node 24.
 - CI/CD: make Vercel the gated production target, deploy the exact tested `main` SHA, stage and verify before promotion, and automatically roll back failed post-promotion checks. ([#140](https://github.com/amanthanvi/BetterMan/pull/140)) — thanks @amanthanvi
 - Performance: metadata-only page reads, split search ranking/headline queries, client-loaded related commands, heuristic document virtualization, near-viewport syntax highlighting, critical-font preloads, and `Server-Timing` diagnostics. ([#139](https://github.com/amanthanvi/BetterMan/pull/139)) — thanks @amanthanvi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to BetterMan are documented here.
 ## Unreleased
 
 - Security: upgrade Click to 8.4.2 to resolve PYSEC-2026-2132 command injection exposure in `click.edit()`.
-- Reliability/accessibility: eliminate transient entrance-animation contrast failures, make man-page find focus deterministic, move dependency review to Node 24, and prevent timed-out Playwright installs from retaining package-manager locks.
+- Reliability/accessibility: eliminate transient entrance-animation contrast failures, make man-page find focus deterministic, retain Vitest DOM matcher types during production builds, move dependency review to Node 24, and prevent timed-out Playwright installs from retaining package-manager locks.
 - CI/CD: make Vercel the gated production target, deploy the exact tested `main` SHA, stage and verify before promotion, and automatically roll back failed post-promotion checks. ([#140](https://github.com/amanthanvi/BetterMan/pull/140)) — thanks @amanthanvi
 - Performance: metadata-only page reads, split search ranking/headline queries, client-loaded related commands, heuristic document virtualization, near-viewport syntax highlighting, critical-font preloads, and `Server-Timing` diagnostics. ([#139](https://github.com/amanthanvi/BetterMan/pull/139)) — thanks @amanthanvi
 - Security: move transitive `brace-expansion` 1.x/2.x overrides beyond GHSA-mh99-v99m-4gvg vulnerable ranges. ([#139](https://github.com/amanthanvi/BetterMan/pull/139))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to BetterMan are documented here.
 ## Unreleased
 
 - Security: upgrade Click to 8.4.2 to resolve PYSEC-2026-2132 command injection exposure in `click.edit()`.
-- Reliability/accessibility: eliminate transient entrance-animation contrast failures, make man-page find focus deterministic, retain Vitest DOM matcher types during production builds, move dependency review to Node 24, and prevent timed-out Playwright installs from retaining package-manager locks.
+- Reliability/accessibility: eliminate transient entrance-animation contrast failures, make man-page find focus deterministic, isolate Vitest DOM matcher types from production source, move dependency review to Node 24, and prevent timed-out Playwright browser downloads from retaining child processes.
 - CI/CD: make Vercel the gated production target, deploy the exact tested `main` SHA, stage and verify before promotion, and automatically roll back failed post-promotion checks. ([#140](https://github.com/amanthanvi/BetterMan/pull/140)) — thanks @amanthanvi
 - Performance: metadata-only page reads, split search ranking/headline queries, client-loaded related commands, heuristic document virtualization, near-viewport syntax highlighting, critical-font preloads, and `Server-Timing` diagnostics. ([#139](https://github.com/amanthanvi/BetterMan/pull/139)) — thanks @amanthanvi
 - Security: move transitive `brace-expansion` 1.x/2.x overrides beyond GHSA-mh99-v99m-4gvg vulnerable ranges. ([#139](https://github.com/amanthanvi/BetterMan/pull/139))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to BetterMan are documented here.
 ## Unreleased
 
 - Security: upgrade Click to 8.4.2 to resolve PYSEC-2026-2132 command injection exposure in `click.edit()`.
-- Reliability/accessibility: eliminate transient entrance-animation contrast failures, make man-page find focus deterministic, and move dependency review to Node 24.
+- Reliability/accessibility: eliminate transient entrance-animation contrast failures, make man-page find focus deterministic, move dependency review to Node 24, and prevent timed-out Playwright installs from retaining package-manager locks.
 - CI/CD: make Vercel the gated production target, deploy the exact tested `main` SHA, stage and verify before promotion, and automatically roll back failed post-promotion checks. ([#140](https://github.com/amanthanvi/BetterMan/pull/140)) — thanks @amanthanvi
 - Performance: metadata-only page reads, split search ranking/headline queries, client-loaded related commands, heuristic document virtualization, near-viewport syntax highlighting, critical-font preloads, and `Server-Timing` diagnostics. ([#139](https://github.com/amanthanvi/BetterMan/pull/139)) — thanks @amanthanvi
 - Security: move transitive `brace-expansion` 1.x/2.x overrides beyond GHSA-mh99-v99m-4gvg vulnerable ranges. ([#139](https://github.com/amanthanvi/BetterMan/pull/139))

--- a/PLAN.md
+++ b/PLAN.md
@@ -409,6 +409,6 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 
 ### CI quality-risk closure (v0.6.5 cycle)
 
-- [x] Remove transient opacity from dialog/palette entrance motion so accessibility checks see stable text contrast.
+- [x] Remove transient opacity from dialog, palette, and findbar entrance motion so accessibility checks see stable text contrast.
 - [x] Focus the man-page find input after commit so Escape handling is deterministic.
 - [x] Upgrade dependency review to its verified Node 24 release.

--- a/PLAN.md
+++ b/PLAN.md
@@ -414,3 +414,4 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 - [x] Focus the man-page find input after commit so Escape handling is deterministic.
 - [x] Upgrade dependency review to its verified Node 24 release.
 - [x] Bound slow Playwright browser installs with process-group termination so retries cannot inherit stale package-manager locks.
+- [x] Include Vitest and Testing Library matcher declarations in the legacy frontend production typecheck.

--- a/PLAN.md
+++ b/PLAN.md
@@ -406,6 +406,7 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 - [x] Add property-based API checks and strictly reject malformed decimal pagination values.
 - [x] Remove vulnerable transitive versions from the pinned Vercel CLI dependency graph.
 - [x] Document the bounded OSV exception for Vercel's unrelated `sandbox@3.4.0` package-name collision.
+- [x] Upgrade transitive Click to 8.4.2 after Scorecards identified PYSEC-2026-2132 (fixed in 8.3.3).
 
 ### CI quality-risk closure (v0.6.5 cycle)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -406,3 +406,9 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 - [x] Add property-based API checks and strictly reject malformed decimal pagination values.
 - [x] Remove vulnerable transitive versions from the pinned Vercel CLI dependency graph.
 - [x] Document the bounded OSV exception for Vercel's unrelated `sandbox@3.4.0` package-name collision.
+
+### CI quality-risk closure (v0.6.5 cycle)
+
+- [x] Remove transient opacity from dialog/palette entrance motion so accessibility checks see stable text contrast.
+- [x] Focus the man-page find input after commit so Escape handling is deterministic.
+- [x] Upgrade dependency review to its verified Node 24 release.

--- a/PLAN.md
+++ b/PLAN.md
@@ -413,5 +413,5 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 - [x] Remove transient opacity from dialog, palette, and findbar entrance motion so accessibility checks see stable text contrast.
 - [x] Focus the man-page find input after commit so Escape handling is deterministic.
 - [x] Upgrade dependency review to its verified Node 24 release.
-- [x] Separate privileged Playwright dependency setup from bounded browser-download retries so retries cannot inherit stale package-manager locks.
+- [x] Bound Playwright dependency/download retries and refuse unsafe same-runner retries after a package-manager timeout.
 - [x] Typecheck legacy frontend tests with isolated Vitest and Testing Library declarations, without exposing test globals to production source.

--- a/PLAN.md
+++ b/PLAN.md
@@ -413,3 +413,4 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 - [x] Remove transient opacity from dialog, palette, and findbar entrance motion so accessibility checks see stable text contrast.
 - [x] Focus the man-page find input after commit so Escape handling is deterministic.
 - [x] Upgrade dependency review to its verified Node 24 release.
+- [x] Bound slow Playwright browser installs with process-group termination so retries cannot inherit stale package-manager locks.

--- a/PLAN.md
+++ b/PLAN.md
@@ -413,5 +413,5 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 - [x] Remove transient opacity from dialog, palette, and findbar entrance motion so accessibility checks see stable text contrast.
 - [x] Focus the man-page find input after commit so Escape handling is deterministic.
 - [x] Upgrade dependency review to its verified Node 24 release.
-- [x] Bound slow Playwright browser installs with process-group termination so retries cannot inherit stale package-manager locks.
-- [x] Include Vitest and Testing Library matcher declarations in the legacy frontend production typecheck.
+- [x] Separate privileged Playwright dependency setup from bounded browser-download retries so retries cannot inherit stale package-manager locks.
+- [x] Typecheck legacy frontend tests with isolated Vitest and Testing Library declarations, without exposing test globals to production source.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -145,14 +145,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]

--- a/frontend/e2e/man.spec.ts
+++ b/frontend/e2e/man.spec.ts
@@ -51,7 +51,6 @@ test('man: sticky sidebar renders TOC; find opens from the title bar (desktop)',
   await page.evaluate(() => {
     const trigger = document.querySelector<HTMLButtonElement>('button[aria-label="Find in page"]')
     if (!trigger) throw new Error('Find trigger is missing')
-    trigger.focus()
     trigger.click()
   })
   await expect(findInput).toBeFocused()

--- a/frontend/e2e/man.spec.ts
+++ b/frontend/e2e/man.spec.ts
@@ -18,6 +18,50 @@ test('man: sticky sidebar renders TOC; find opens from the title bar (desktop)',
   await expect(findInput).toBeFocused()
   await findTrigger.click()
   await expect(findInput).toBeFocused()
+  await page.evaluate(() => {
+    const originalRequestAnimationFrame = window.requestAnimationFrame.bind(window)
+    const originalCancelAnimationFrame = window.cancelAnimationFrame.bind(window)
+    const pendingFrames = new Map<number, FrameRequestCallback>()
+    let nextFrameId = 1_000_000
+
+    window.requestAnimationFrame = (callback) => {
+      const frameId = nextFrameId
+      nextFrameId += 1
+      pendingFrames.set(frameId, callback)
+      return frameId
+    }
+    window.cancelAnimationFrame = (frameId) => {
+      pendingFrames.delete(frameId)
+    }
+
+    ;(
+      window as Window & {
+        __bmFlushFocusFrames?: () => void
+      }
+    ).__bmFlushFocusFrames = () => {
+      window.requestAnimationFrame = originalRequestAnimationFrame
+      window.cancelAnimationFrame = originalCancelAnimationFrame
+      const callbacks = [...pendingFrames.values()]
+      pendingFrames.clear()
+      callbacks.forEach((callback) => callback(performance.now()))
+    }
+  })
+  await page.keyboard.press('Escape')
+  await expect(page.locator('[data-bm-findbar]')).toHaveCount(0)
+  await page.evaluate(() => {
+    const trigger = document.querySelector<HTMLButtonElement>('button[aria-label="Find in page"]')
+    if (!trigger) throw new Error('Find trigger is missing')
+    trigger.focus()
+    trigger.click()
+  })
+  await expect(findInput).toBeFocused()
+  await page.evaluate(() => {
+    const testWindow = window as Window & { __bmFlushFocusFrames?: () => void }
+    if (!testWindow.__bmFlushFocusFrames) throw new Error('Focus-frame test harness is missing')
+    testWindow.__bmFlushFocusFrames()
+    delete testWindow.__bmFlushFocusFrames
+  })
+  await expect(findInput).toBeFocused()
   await page.keyboard.press('Escape')
   await expect(page.locator('[data-bm-findbar]')).toHaveCount(0)
   await expect(findTrigger).toBeFocused()

--- a/frontend/e2e/man.spec.ts
+++ b/frontend/e2e/man.spec.ts
@@ -13,8 +13,11 @@ test('man: sticky sidebar renders TOC; find opens from the title bar (desktop)',
 
   await waitForInteractiveShell(page)
   const findTrigger = page.getByRole('button', { name: 'Find in page' })
+  const findInput = page.locator('[data-bm-findbar]').getByRole('textbox', { name: 'Find in page' })
   await findTrigger.click()
-  await expect(page.locator('[data-bm-findbar]').getByRole('textbox', { name: 'Find in page' })).toBeVisible()
+  await expect(findInput).toBeFocused()
+  await findTrigger.click()
+  await expect(findInput).toBeFocused()
   await page.keyboard.press('Escape')
   await expect(page.locator('[data-bm-findbar]')).toHaveCount(0)
   await expect(findTrigger).toBeFocused()

--- a/frontend/e2e/palette.spec.ts
+++ b/frontend/e2e/palette.spec.ts
@@ -42,6 +42,34 @@ test('keyboard shortcuts dialog: a11y after immediate reopen', async ({ page }) 
     .locator('[data-state]')
     .filter({ has: page.locator('button[aria-label="Close keyboard shortcuts"]') })
   await expect(closeButton).toBeVisible()
+  await page.evaluate(() => {
+    const originalSetTimeout = window.setTimeout.bind(window)
+    const originalClearTimeout = window.clearTimeout.bind(window)
+    const heldExitTimers = new Map<number, () => void>()
+    let nextTimerId = 1_000_000
+
+    window.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+      if (timeout === 200 && typeof handler === 'function') {
+        const timerId = nextTimerId
+        nextTimerId += 1
+        heldExitTimers.set(timerId, () => handler())
+        return timerId
+      }
+      return originalSetTimeout(handler, timeout, ...args)
+    }) as typeof window.setTimeout
+    window.clearTimeout = ((timerId?: number) => {
+      if (timerId !== undefined && heldExitTimers.delete(timerId)) return
+      originalClearTimeout(timerId)
+    }) as typeof window.clearTimeout
+
+    ;(window as Window & { __bmFlushExitTimers?: () => void }).__bmFlushExitTimers = () => {
+      window.setTimeout = originalSetTimeout
+      window.clearTimeout = originalClearTimeout
+      const callbacks = [...heldExitTimers.values()]
+      heldExitTimers.clear()
+      callbacks.forEach((callback) => callback())
+    }
+  })
   await closeButton.click()
   await expect(dialogPanel).toHaveAttribute('data-state', 'closed')
   await expect(dialogPanel).toBeAttached()
@@ -49,5 +77,12 @@ test('keyboard shortcuts dialog: a11y after immediate reopen', async ({ page }) 
   await page.keyboard.type('?')
   await expect(dialog).toBeVisible()
   await expect(closeButton).toBeVisible()
+  await page.evaluate(() => {
+    const testWindow = window as Window & { __bmFlushExitTimers?: () => void }
+    if (!testWindow.__bmFlushExitTimers) throw new Error('Exit-timer test harness is missing')
+    testWindow.__bmFlushExitTimers()
+    delete testWindow.__bmFlushExitTimers
+  })
+  await expect(dialog).toBeVisible()
   await expectNoCriticalOrSeriousViolations(page)
 })

--- a/frontend/e2e/palette.spec.ts
+++ b/frontend/e2e/palette.spec.ts
@@ -30,3 +30,18 @@ test('command palette: a11y (no critical/serious violations)', async ({ page }) 
   await expect(page.getByRole('combobox', { name: 'Command palette input' })).toBeVisible()
   await expectNoCriticalOrSeriousViolations(page)
 })
+
+test('keyboard shortcuts dialog: a11y after immediate reopen', async ({ page }) => {
+  await page.goto('/')
+  await waitForInteractiveShell(page)
+
+  await page.keyboard.type('?')
+  const dialog = page.getByRole('dialog', { name: 'Keyboard shortcuts' })
+  const closeButton = page.getByRole('button', { name: 'Close keyboard shortcuts' })
+  await expect(closeButton).toBeVisible()
+  await closeButton.click()
+  await page.keyboard.type('?')
+  await expect(dialog).toBeVisible()
+  await expect(closeButton).toBeVisible()
+  await expectNoCriticalOrSeriousViolations(page)
+})

--- a/frontend/e2e/palette.spec.ts
+++ b/frontend/e2e/palette.spec.ts
@@ -38,11 +38,14 @@ test('keyboard shortcuts dialog: a11y after immediate reopen', async ({ page }) 
   await page.keyboard.type('?')
   const dialog = page.getByRole('dialog', { name: 'Keyboard shortcuts' })
   const closeButton = page.getByRole('button', { name: 'Close keyboard shortcuts' })
+  const dialogPanel = page
+    .locator('[data-state]')
+    .filter({ has: page.locator('button[aria-label="Close keyboard shortcuts"]') })
   await expect(closeButton).toBeVisible()
   await closeButton.click()
-  await expect(
-    page.locator('[role="dialog"][aria-label="Keyboard shortcuts"] [data-state="closed"]'),
-  ).toBeAttached()
+  await expect(dialogPanel).toHaveAttribute('data-state', 'closed')
+  await expect(dialogPanel).toBeAttached()
+  await expect(dialog).toHaveCount(0)
   await page.keyboard.type('?')
   await expect(dialog).toBeVisible()
   await expect(closeButton).toBeVisible()

--- a/frontend/e2e/palette.spec.ts
+++ b/frontend/e2e/palette.spec.ts
@@ -40,6 +40,9 @@ test('keyboard shortcuts dialog: a11y after immediate reopen', async ({ page }) 
   const closeButton = page.getByRole('button', { name: 'Close keyboard shortcuts' })
   await expect(closeButton).toBeVisible()
   await closeButton.click()
+  await expect(
+    page.locator('[role="dialog"][aria-label="Keyboard shortcuts"] [data-state="closed"]'),
+  ).toBeAttached()
   await page.keyboard.type('?')
   await expect(dialog).toBeVisible()
   await expect(closeButton).toBeVisible()

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
+    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.test.json" },
     { "path": "./tsconfig.node.json" }
   ]
 }

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom/vitest"],
+    "paths": {
+      "vitest": ["./node_modules/vitest"]
+    }
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**/*.ts", "src/test/**/*.tsx"],
+  "exclude": []
+}

--- a/nextjs/app/globals.css
+++ b/nextjs/app/globals.css
@@ -278,11 +278,9 @@
 
     @keyframes bm-pop-in {
       from {
-        opacity: 0;
         transform: scale(0.98);
       }
       to {
-        opacity: 1;
         transform: none;
       }
     }

--- a/nextjs/app/globals.css
+++ b/nextjs/app/globals.css
@@ -291,11 +291,9 @@
 
     @keyframes bm-rise-in {
       from {
-        opacity: 0;
         transform: translateY(4px);
       }
       to {
-        opacity: 1;
         transform: none;
       }
     }

--- a/nextjs/components/man/useManPageFind.ts
+++ b/nextjs/components/man/useManPageFind.ts
@@ -16,6 +16,7 @@ export function useManPageFind({ blocks }: { blocks: BlockNode[] }) {
 
   const activeMarkRef = useRef<HTMLElement | null>(null)
   const focusRestoreFrameRef = useRef<number | null>(null)
+  const pendingFocusRestoreTargetRef = useRef<HTMLElement | null>(null)
   const previouslyFocusedRef = useRef<HTMLElement | null>(null)
   const findInputRef = useRef<HTMLInputElement | null>(null)
   const docRef = useRef<DocRendererHandle | null>(null)
@@ -70,17 +71,23 @@ export function useManPageFind({ blocks }: { blocks: BlockNode[] }) {
   useEffect(
     () => () => {
       if (focusRestoreFrameRef.current !== null) window.cancelAnimationFrame(focusRestoreFrameRef.current)
+      pendingFocusRestoreTargetRef.current = null
     },
     [],
   )
 
   const openFind = () => {
+    const restoreWasPending = focusRestoreFrameRef.current !== null
     if (focusRestoreFrameRef.current !== null) {
       window.cancelAnimationFrame(focusRestoreFrameRef.current)
       focusRestoreFrameRef.current = null
+      previouslyFocusedRef.current = pendingFocusRestoreTargetRef.current
+      pendingFocusRestoreTargetRef.current = null
     }
     if (!findOpen) {
-      previouslyFocusedRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
+      if (!restoreWasPending) {
+        previouslyFocusedRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
+      }
       setFindOpen(true)
       return
     }
@@ -162,10 +169,13 @@ export function useManPageFind({ blocks }: { blocks: BlockNode[] }) {
     activeMarkRef.current = null
     const previouslyFocused = previouslyFocusedRef.current
     previouslyFocusedRef.current = null
+    pendingFocusRestoreTargetRef.current = previouslyFocused
     setFindOpen(false)
     focusRestoreFrameRef.current = window.requestAnimationFrame(() => {
       focusRestoreFrameRef.current = null
-      previouslyFocused?.focus({ preventScroll: true })
+      const focusTarget = pendingFocusRestoreTargetRef.current
+      pendingFocusRestoreTargetRef.current = null
+      focusTarget?.focus({ preventScroll: true })
     })
   }
 

--- a/nextjs/components/man/useManPageFind.ts
+++ b/nextjs/components/man/useManPageFind.ts
@@ -8,6 +8,7 @@ import type { DocRendererHandle } from '../doc/DocRenderer'
 import { buildFindIndex, locateFindMatch } from './findIndex'
 
 const FIND_DEBOUNCE_MS = 150
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect
 
 export function useManPageFind({ blocks }: { blocks: BlockNode[] }) {
   const [find, setFind] = useState('')
@@ -63,7 +64,7 @@ export function useManPageFind({ blocks }: { blocks: BlockNode[] }) {
     el?.select()
   }, [])
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!findOpen) return
     focusFindInput()
   }, [findOpen, focusFindInput])
@@ -165,6 +166,7 @@ export function useManPageFind({ blocks }: { blocks: BlockNode[] }) {
   }
 
   const closeFind = () => {
+    if (focusRestoreFrameRef.current !== null) return
     if (activeMarkRef.current) activeMarkRef.current.classList.remove('bm-find-active')
     activeMarkRef.current = null
     const previouslyFocused = previouslyFocusedRef.current

--- a/nextjs/components/man/useManPageFind.ts
+++ b/nextjs/components/man/useManPageFind.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import type { BlockNode } from '../../lib/docModel'
 import { getScrollBehavior } from '../../lib/scroll'
@@ -55,24 +55,24 @@ export function useManPageFind({ blocks }: { blocks: BlockNode[] }) {
           ? `${displayIndex + 1}/${matchCount}`
           : '0/0'
 
-  const focusFindInput = () => {
+  const focusFindInput = useCallback(() => {
     const el = findInputRef.current
     el?.focus()
     el?.select()
-  }
+  }, [])
 
   useLayoutEffect(() => {
     if (!findOpen) return
-    const input = findInputRef.current
-    input?.focus()
-    input?.select()
-  }, [findOpen])
+    focusFindInput()
+  }, [findOpen, focusFindInput])
 
   const openFind = () => {
     if (!findOpen) {
       previouslyFocusedRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
+      setFindOpen(true)
+      return
     }
-    setFindOpen(true)
+    focusFindInput()
   }
 
   const scrollToFind = (idx: number) => {

--- a/nextjs/components/man/useManPageFind.ts
+++ b/nextjs/components/man/useManPageFind.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import type { BlockNode } from '../../lib/docModel'
 import { getScrollBehavior } from '../../lib/scroll'
@@ -61,12 +61,18 @@ export function useManPageFind({ blocks }: { blocks: BlockNode[] }) {
     el?.select()
   }
 
+  useLayoutEffect(() => {
+    if (!findOpen) return
+    const input = findInputRef.current
+    input?.focus()
+    input?.select()
+  }, [findOpen])
+
   const openFind = () => {
     if (!findOpen) {
       previouslyFocusedRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
     }
     setFindOpen(true)
-    requestAnimationFrame(() => focusFindInput())
   }
 
   const scrollToFind = (idx: number) => {

--- a/nextjs/components/man/useManPageFind.ts
+++ b/nextjs/components/man/useManPageFind.ts
@@ -15,6 +15,7 @@ export function useManPageFind({ blocks }: { blocks: BlockNode[] }) {
   const [activeFindIndex, setActiveFindIndex] = useState(0)
 
   const activeMarkRef = useRef<HTMLElement | null>(null)
+  const focusRestoreFrameRef = useRef<number | null>(null)
   const previouslyFocusedRef = useRef<HTMLElement | null>(null)
   const findInputRef = useRef<HTMLInputElement | null>(null)
   const docRef = useRef<DocRendererHandle | null>(null)
@@ -66,7 +67,18 @@ export function useManPageFind({ blocks }: { blocks: BlockNode[] }) {
     focusFindInput()
   }, [findOpen, focusFindInput])
 
+  useEffect(
+    () => () => {
+      if (focusRestoreFrameRef.current !== null) window.cancelAnimationFrame(focusRestoreFrameRef.current)
+    },
+    [],
+  )
+
   const openFind = () => {
+    if (focusRestoreFrameRef.current !== null) {
+      window.cancelAnimationFrame(focusRestoreFrameRef.current)
+      focusRestoreFrameRef.current = null
+    }
     if (!findOpen) {
       previouslyFocusedRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
       setFindOpen(true)
@@ -151,7 +163,10 @@ export function useManPageFind({ blocks }: { blocks: BlockNode[] }) {
     const previouslyFocused = previouslyFocusedRef.current
     previouslyFocusedRef.current = null
     setFindOpen(false)
-    window.requestAnimationFrame(() => previouslyFocused?.focus({ preventScroll: true }))
+    focusRestoreFrameRef.current = window.requestAnimationFrame(() => {
+      focusRestoreFrameRef.current = null
+      previouslyFocused?.focus({ preventScroll: true })
+    })
   }
 
   return {

--- a/nextjs/components/ui/Dialog.tsx
+++ b/nextjs/components/ui/Dialog.tsx
@@ -59,9 +59,9 @@ export function Overlay({
 
   return createPortal(
     <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={label}
+      role={open ? 'dialog' : undefined}
+      aria-modal={open ? true : undefined}
+      aria-label={open ? label : undefined}
       className={cx('fixed inset-0 z-50', open ? 'pointer-events-auto' : 'pointer-events-none')}
       onClick={() => onOpenChange(false)}
     >

--- a/nextjs/components/ui/Dialog.tsx
+++ b/nextjs/components/ui/Dialog.tsx
@@ -12,7 +12,7 @@ const EXIT_MS = 200
 
 /**
  * Shared overlay chassis: portal, scrim, focus trap, scroll lock, Escape,
- * click-outside, and enter/exit opacity. Dialog and Drawer both sit on it.
+ * click-outside, and scrim transition. Dialog and Drawer both sit on it.
  */
 export function Overlay({
   open,
@@ -101,8 +101,8 @@ export function Dialog({
       onOpenChange={onOpenChange}
       label={label}
       positionClassName={cx(
-        'bm-pop-in relative mx-auto mt-24 w-[min(92vw,38rem)] border border-edge bg-raised p-6 shadow-lg shadow-black/25 transition-opacity motion-reduce:animate-none motion-reduce:transition-none',
-        open ? 'opacity-100' : 'opacity-0',
+        'bm-pop-in relative mx-auto mt-24 w-[min(92vw,38rem)] border border-edge bg-raised p-6 shadow-lg shadow-black/25 motion-reduce:animate-none',
+        open ? 'visible' : 'invisible',
       )}
       panelClassName={panelClassName}
     >


### PR DESCRIPTION
## What

- remove transient opacity from dialog, palette, and findbar motion so accessibility checks see stable contrast
- make man-page find focus deterministic, cancel stale restoration frames, and cover close-to-reopen behavior
- add an immediate dialog-reopen accessibility regression
- upgrade dependency review to verified v5.0.0 on Node 24
- harden Playwright browser-install retries with bounded captured-process-group cleanup
- restore Vitest DOM matcher types in the production typecheck
- upgrade transitive Click to 8.4.2, resolving PYSEC-2026-2132
- record the v0.6.5 quality and security closure in PLAN.md and CHANGELOG.md

## Why

The merge train exposed transient Axe contrast failures, focus races, a package-manager lock leak after timed-out browser installation, a legacy frontend typecheck failure, and a high-severity Click command-injection advisory.

## Validation

- focused palette accessibility stress: 20/20
- focused dialog immediate-reopen accessibility stress: 20/20
- focused man findbar focus stress: 20/20
- Next lint, 29/29 tests, production build, and visual grammar: pass
- frontend lint, 4/4 tests, production build, and bundle report: pass
- backend lint and 22/22 tests: pass
- ingestion lint and 47/47 tests: pass
- Click 8.4.2 OSV query: zero vulnerabilities
- workflow Bash parse and diff checks: pass

## Checklist

- [x] all known external review findings addressed
- [x] focused race and accessibility regressions stress-tested
- [x] local quality matrix passed
- [x] security lockfile remediation verified
- [x] PLAN and CHANGELOG updated

## Summary by Sourcery

Resolve CI-accessibility instability, focus races, and a transitive security advisory while tightening Playwright setup robustness and restoring legacy frontend type-checking coverage.

Bug Fixes:
- Fix keyboard shortcuts dialog immediate-reopen behavior to maintain stable accessibility state and contrast.
- Make the man-page findbar focus behavior deterministic across open/close cycles, avoiding stale focus restoration frames.
- Prevent timed-out Playwright dependency and browser installs from leaving orphaned processes or unsafe dpkg retries.
- Restore Vitest DOM matcher typings to the production type-check to cover legacy frontend tests without leaking test globals.
- Eliminate transient opacity-based entrance animations that caused intermittent accessibility contrast violations in dialogs and overlays.
- Upgrade transitive Click to 8.4.2 to remediate the PYSEC-2026-2132 command injection vulnerability.

Enhancements:
- Strengthen the dependency-review GitHub Action by moving to the verified v5.0.0 release on Node 24.

Build:
- Include the frontend test TypeScript configuration in the composite project graph so legacy test typings participate in production type-checking.

CI:
- Harden Playwright installation in CI with bounded, timed retries for dependencies and browser downloads while preserving the job time budget.

Documentation:
- Record the v0.6.5 CI quality and security closure in PLAN.md and CHANGELOG.md, including accessibility, dependency, and Click remediation notes.

Tests:
- Add focused end-to-end accessibility regression coverage for immediate dialog reopen and man-page findbar focus restoration behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved find-in-page focus behavior when opening, reopening, and closing the panel.
  * Stabilized animation behavior to support more reliable accessibility interactions.
  * Improved keyboard shortcut dialog behavior, including closing and immediately reopening it.

* **Bug Fixes**
  * Dialog visibility transitions are now more consistent, reducing flicker during open and close actions.

* **Documentation**
  * Updated release documentation with accessibility, reliability, and security improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->