### PR TITLE
fix: patch nanoid advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to BetterMan are documented here.
 
 ## Unreleased
 
+- Security: pin transitive `nanoid` 3.x to 3.3.17 to resolve GHSA-2v37-7h3g-55p8.
 - Security: remove caller-controlled dataset routing from anonymous Convex queries/actions, force public reads to `prod`, and contract-test the rollback-compatible boundary in CI.
 - Reliability: scope Convex ingestion credentials to the protected GitHub `production` environment and validate them before starting Linux, macOS, or FreeBSD ingestion runners.
 - Reliability: restore and contract-test the monthly dataset schedule, gate promotion on all selected ingests and distro pointers, add a non-active FreeBSD VM sample path, and enforce Playwright/OSV automation contracts in CI.

--- a/PLAN.md
+++ b/PLAN.md
@@ -407,6 +407,7 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 - [x] Remove vulnerable transitive versions from the pinned Vercel CLI dependency graph.
 - [x] Document the bounded OSV exception for Vercel's unrelated `sandbox@3.4.0` package-name collision.
 - [x] Upgrade transitive Click to 8.4.2 after Scorecards identified PYSEC-2026-2132 (fixed in 8.3.3).
+- [x] Pin transitive `nanoid` 3.x to 3.3.17 after Dependabot identified GHSA-2v37-7h3g-55p8.
 
 ### CI quality-risk closure (v0.6.5 cycle)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ overrides:
   '@tootallnate/once@2': 2.0.1
   ajv@8: 8.18.0
   minimatch@10: 10.2.4
+  nanoid@3: 3.3.17
   path-to-regexp@>=4 <6.3.0: 6.3.0
   path-to-regexp@8: 8.4.0
   smol-toml@1: 1.6.1
@@ -4200,8 +4201,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -9424,7 +9425,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -9677,7 +9678,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ overrides:
   "@tootallnate/once@2": "2.0.1"
   "ajv@8": "8.18.0"
   "minimatch@10": "10.2.4"
+  "nanoid@3": "3.3.17"
   "path-to-regexp@>=4 <6.3.0": "6.3.0"
   "path-to-regexp@8": "8.4.0"
   "smol-toml@1": "1.6.1"


### PR DESCRIPTION
## Summary
- pin transitive nanoid 3.x to patched 3.3.17
- resolve GHSA-2v37-7h3g-55p8 / Dependabot alert #142
- record the v0.6.5 supply-chain closure

## Validation
- pnpm install --frozen-lockfile
- pnpm why nanoid -r (single 3.3.17 resolution)
- pnpm audit --prod (no known vulnerabilities)
- pnpm next:lint
- pnpm next:test (9 files, 29 tests)
- pnpm next:build
- git diff --check

## Summary by Sourcery

Pin the transitive nanoid dependency to a patched version to address a reported security advisory and record the change in project planning and release notes.

Bug Fixes:
- Resolve the GHSA-2v37-7h3g-55p8 advisory by forcing nanoid 3.x to use version 3.3.17 across the workspace.

Build:
- Add a pnpm workspace override to pin nanoid@3 to version 3.3.17 for all packages.

Documentation:
- Update CHANGELOG and PLAN to document the nanoid security fix and its inclusion in the v0.6.5 cycle.