### PR TITLE
chore: release v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to BetterMan are documented here.
 
 ## Unreleased
 
+## v0.6.5
+
 - Security: pin transitive `nanoid` 3.x to 3.3.17 to resolve GHSA-2v37-7h3g-55p8.
 - Security: remove caller-controlled dataset routing from anonymous Convex queries/actions, force public reads to `prod`, and contract-test the rollback-compatible boundary in CI.
 - Reliability: scope Convex ingestion credentials to the protected GitHub `production` environment and validate them before starting Linux, macOS, or FreeBSD ingestion runners.

--- a/PLAN.md
+++ b/PLAN.md
@@ -29,6 +29,7 @@ Living execution plan for shipping `v0.6.0` from `SPEC.md`.
 - [x] v0.6.2 shipped (tag `v0.6.2`)
 - [x] v0.6.3 shipped (tag `v0.6.3`)
 - [x] v0.6.4 shipped (tag `v0.6.4`)
+- [x] v0.6.5 shipped (tag `v0.6.5`)
 
 ## Golden Commands (current; proven)
 
@@ -384,7 +385,7 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 - [x] Stop blocking man page SSR on related-command fetch (load related client-side after first paint).
 - [x] Improve large man-page rendering with heuristic virtualization + viewport-gated code highlighting.
 - [x] Preload critical fonts to reduce first-paint CLS on man pages.
-- [ ] Tag `v0.6.5`
+- [x] Tag `v0.6.5`
 
 ### Production delivery hardening (v0.6.5 cycle)
 
@@ -427,4 +428,4 @@ Theme: **Design & UI/UX Overhaul — Hacker-Tool Aesthetic**
 - [x] Fail closed when the bounded OSV exception's advisory set, Vercel dependency edge, package version, evidence, or 30-day review window drifts.
 - [x] Move `brace-expansion` 5.x to 5.0.9 after registry audit identified GHSA-rgw5-rvv9-x895.
 - [x] Move `js-yaml` 4.x to 4.3.1 after registry audit identified GHSA-5p4m-2wfm-xmqj.
-- [ ] Run the FreeBSD sample on the merged workflow; verify promotion stays skipped and production remains on the independently deployed main SHA.
+- [x] Run the FreeBSD sample on the merged workflow; run `31330645098` ingested 4/4 pages with `published:false`, skipped promotion, and left production on the independently deployed main SHA.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
-# BetterMan — PLAN (v0.6.0)
+# BetterMan — PLAN
 
-Living execution plan for shipping `v0.6.0` from `SPEC.md`.
+Living execution plan for BetterMan from `SPEC.md`.
 
 - Branch: `main` (small/medium diffs; commit + push frequently)
 - Principle: fix root causes; no drive‑by refactors

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ BetterMan is a fast, readable web UI for `man` pages — built to feel like a to
 
 ## Status
 
-- Latest release: `v0.6.4` (tag `v0.6.4`)
-- In progress: `v0.6.5` (see `ROADMAP.md` + `PLAN.md`)
+- Latest release: `v0.6.5` (tag `v0.6.5`)
 - Default branch: `main`
 
 ## Deploy (Vercel)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ This project is actively evolving.
 
 ## Current focus
 
-- `v0.6.0` shipped. Next: papercuts + follow-ups (TBD).
+- `v0.6.5` shipped. Next: papercuts + follow-ups (TBD).
 
 ## How to help
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,9 +1,9 @@
 # 1. Title / Version / Status
 
 **Project:** BetterMan
-**Spec Version:** v0.6.0
-**Status:** v0.6.4 shipped (v0.6.3 shipped, v0.6.2 shipped, v0.6.1 shipped, v0.6.0 shipped, v0.5.0 shipped, v0.4.0 shipped, v0.3.0 shipped, v0.2.1 shipped, v0.2.0 shipped, v0.1.2 shipped, v0.1.1 shipped, v0.1.0 shipped)
-**Last Updated:** 2026-02-24 (EST)
+**Spec Version:** v0.6.5
+**Status:** v0.6.5 shipped (v0.6.4 shipped, v0.6.3 shipped, v0.6.2 shipped, v0.6.1 shipped, v0.6.0 shipped, v0.5.0 shipped, v0.4.0 shipped, v0.3.0 shipped, v0.2.1 shipped, v0.2.0 shipped, v0.1.2 shipped, v0.1.1 shipped, v0.1.0 shipped)
+**Last Updated:** 2026-08-09 (EDT)
 **Interview Status:** Complete - v0.6.0 scoped
 
 ---

--- a/nextjs/public/sw.js
+++ b/nextjs/public/sw.js
@@ -1,6 +1,6 @@
 /* BetterMan service worker (minimal, no Workbox). */
 
-const CACHE_VERSION = 'v0.6.4'
+const CACHE_VERSION = 'v0.6.5'
 const CACHE_PREFIX = 'bm'
 
 const STATIC_CACHE = `${CACHE_PREFIX}-static-${CACHE_VERSION}`


### PR DESCRIPTION
## Summary
- cut the v0.6.5 changelog and align README, roadmap, plan, and spec status
- record the successful non-publishing FreeBSD sample validation
- bump the service-worker cache version so clients invalidate v0.6.4 assets

## Validation
- pnpm next:lint
- pnpm next:test (9 files, 29 tests)
- pnpm next:build
- git diff --check

## Summary by Sourcery

Prepare and document the v0.6.5 release and ensure clients pick up the new version.

Enhancements:
- Update spec, plan, roadmap, README, and changelog to reflect v0.6.5 as the latest shipped release.
- Record successful FreeBSD ingestion sample run details in the execution plan.

Deployment:
- Bump the service worker cache version to v0.6.5 so clients invalidate v0.6.4 assets.

Documentation:
- Add the v0.6.5 section to the changelog describing security and reliability changes.